### PR TITLE
Phase 1: Skill surface rewrite and worker task specs

### DIFF
--- a/geo/SKILL.md
+++ b/geo/SKILL.md
@@ -1,231 +1,93 @@
 ---
 name: geo
 description: >
-  GEO-first SEO analysis tool. Optimizes websites for AI-powered search engines
-  (ChatGPT, Claude, Perplexity, Gemini, Google AI Overviews) while maintaining
-  traditional SEO foundations. Performs full GEO audits, citability scoring,
-  AI crawler analysis, llms.txt generation, brand mention scanning, platform-specific
-  optimization, schema markup, technical SEO, content quality (E-E-A-T), and
-  client-ready GEO report generation. Use when user says "geo", "seo", "audit",
-  "AI search", "AI visibility", "optimize", "citability", "llms.txt", "schema",
-  "brand mentions", "GEO report", or any URL for analysis.
-allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+  GEO analysis tool. Audits websites for AI search visibility across ChatGPT, Claude,
+  Perplexity, Gemini, and Google AI Overviews. Scores citability, AI crawler access,
+  llms.txt, brand signals, schema markup, technical health, and E-E-A-T content quality.
+  Adapted from geo-seo-claude by Zubair Trabzada. Use when user says "geo", "seo",
+  "audit", "AI search", "AI visibility", "citability", "llms.txt", "schema", "brand
+  mentions", or any URL for analysis.
 ---
 
-# GEO-SEO Analysis Tool — Claude Code Skill (February 2026)
+# GEO — Generative Engine Optimization Analysis
 
 > **Philosophy:** GEO-first, SEO-supported. AI search is eating traditional search.
-> This tool optimizes for where traffic is going, not where it was.
+> Optimize for where traffic is going.
 
 ---
 
-## Quick Reference
+## Commands
 
-| Command | What It Does |
-|---------|-------------|
-| `/geo audit <url>` | Full GEO + SEO audit with parallel subagents |
-| `/geo page <url>` | Deep single-page GEO analysis |
-| `/geo citability <url>` | Score content for AI citation readiness |
-| `/geo crawlers <url>` | Check AI crawler access (robots.txt analysis) |
-| `/geo llmstxt <url>` | Analyze or generate llms.txt file |
-| `/geo brands <url>` | Scan brand mentions across AI-cited platforms |
-| `/geo platforms <url>` | Platform-specific optimization (ChatGPT, Perplexity, Google AIO) |
-| `/geo schema <url>` | Detect, validate, and generate structured data |
-| `/geo technical <url>` | Traditional technical SEO audit |
-| `/geo content <url>` | Content quality and E-E-A-T assessment |
-| `/geo report <url>` | Generate client-ready GEO deliverable |
-| `/geo report-pdf <url>` | Generate professional PDF report with charts and scores |
-| `/geo quick <url>` | 60-second GEO visibility snapshot |
-| `/geo prospect <cmd>` | CRM-lite: manage prospects through the sales pipeline |
-| `/geo proposal <domain>` | Auto-generate client proposal from audit data |
-| `/geo compare <domain>` | Monthly delta report: show score improvements to client |
+| Command | What It Does | Target Time |
+|---|---|---|
+| `/geo audit <url>` | Full GEO audit — all 8 workers in parallel, composite score | 3–5 min |
+| `/geo quick <url>` | Same methodology, shallower checks — fewer pages, reduced sample sizes | ~60s |
+| `/geo citability <url>` | Passage-level AI citation readiness | — |
+| `/geo crawlers <url>` | AI crawler access map from robots.txt | — |
+| `/geo llmstxt <url>` | Validate existing or generate new llms.txt | — |
+| `/geo brands <url>` | Off-site brand presence (YouTube, Reddit, Wikipedia, LinkedIn) | — |
+| `/geo schema <url>` | JSON-LD detection, validation, and generation | — |
+| `/geo technical <url>` | Core Web Vitals, SSR, mobile, crawlability | — |
+| `/geo content <url>` | E-E-A-T, author authority, freshness, topical depth | — |
+| `/geo platforms <url>` | AI platform-specific score interpretation | — |
 
 ---
 
-## Market Context (Why GEO Matters)
+## Scoring Methodology
 
-| Metric | Value | Source |
-|--------|-------|--------|
-| GEO services market (2025) | $850M-$886M | Yahoo Finance / Superlines |
-| Projected GEO market (2031) | $7.3B (34% CAGR) | Industry analysts |
-| AI-referred sessions growth | +527% (Jan-May 2025) | SparkToro |
-| AI traffic conversion vs organic | 4.4x higher | Industry data |
-| Google AI Overviews reach | 1.5B users/month, 200+ countries | Google |
-| ChatGPT weekly active users | 900M+ | OpenAI |
-| Perplexity monthly queries | 500M+ | Perplexity |
-| Gartner: search traffic drop by 2028 | -50% | Gartner |
-| Marketers investing in GEO | Only 23% | Industry surveys |
-| Brand mentions vs backlinks for AI | 3x stronger correlation | Ahrefs (Dec 2025) |
+All categories feed the composite GEO Score (0–100):
+
+| Category | Weight | Sub-skill |
+|---|---|---|
+| AI Citability | 25% | `skills/geo-citability/` |
+| Brand Authority | 20% | `skills/geo-brand-mentions/` |
+| Content E-E-A-T | 20% | `skills/geo-content/` |
+| Technical GEO | 15% | `skills/geo-technical/` |
+| Schema & Structured Data | 10% | `skills/geo-schema/` |
+| Platform Optimization | 10% | `skills/geo-platform-optimizer/` |
 
 ---
 
-## Orchestration Logic
+## Sub-Skills (9 Components)
 
-### Full Audit (`/geo audit <url>`)
-
-**Phase 1: Discovery (Sequential)**
-1. Fetch homepage HTML (curl or WebFetch)
-2. Detect business type (SaaS, Local, E-commerce, Publisher, Agency, Other)
-3. Extract key pages from sitemap.xml or internal links (up to 50 pages)
-
-**Phase 2: Parallel Analysis (Delegate to Subagents)**
-Launch these 5 subagents simultaneously:
-
-| Subagent | File | Responsibility |
-|----------|------|---------------|
-| geo-ai-visibility | `agents/geo-ai-visibility.md` | GEO audit, citability, AI crawlers, llms.txt, brand mentions |
-| geo-platform-analysis | `agents/geo-platform-analysis.md` | Platform-specific optimization (ChatGPT, Perplexity, Google AIO) |
-| geo-technical | `agents/geo-technical.md` | Technical SEO, Core Web Vitals, crawlability, indexability |
-| geo-content | `agents/geo-content.md` | Content quality, E-E-A-T, readability, AI content detection |
-| geo-schema | `agents/geo-schema.md` | Schema markup detection, validation, generation |
-
-**Phase 3: Synthesis (Sequential)**
-1. Collect all subagent reports
-2. Calculate composite GEO Score (0-100)
-3. Generate prioritized action plan
-4. Output client-ready report
-
-### Scoring Methodology
-
-| Category | Weight | Measured By |
-|----------|--------|-------------|
-| AI Citability & Visibility | 25% | Passage scoring, answer block quality, AI crawler access |
-| Brand Authority Signals | 20% | Mentions on Reddit, YouTube, Wikipedia, LinkedIn; entity presence |
-| Content Quality & E-E-A-T | 20% | Expertise signals, original data, author credentials |
-| Technical Foundations | 15% | SSR, Core Web Vitals, crawlability, mobile, security |
-| Structured Data | 10% | Schema completeness, JSON-LD validation, rich result eligibility |
-| Platform Optimization | 10% | Platform-specific readiness (Google AIO, ChatGPT, Perplexity) |
+| Sub-skill | Directory | Domain |
+|---|---|---|
+| geo-audit | `skills/geo-audit/` | Orchestration — synthesises all 8 worker outputs |
+| geo-citability | `skills/geo-citability/` | Passage-level AI citation readiness |
+| geo-crawlers | `skills/geo-crawlers/` | AI crawler access, robots.txt |
+| geo-llmstxt | `skills/geo-llmstxt/` | llms.txt presence, validity, generation |
+| geo-brand-mentions | `skills/geo-brand-mentions/` | Off-site brand signals (STUB — see issue #3) |
+| geo-platform-optimizer | `skills/geo-platform-optimizer/` | AI platform interpretation (STUB — see issue #2) |
+| geo-schema | `skills/geo-schema/` | JSON-LD detection, validation, generation |
+| geo-technical | `skills/geo-technical/` | Core Web Vitals, SSR, mobile, security |
+| geo-content | `skills/geo-content/` | E-E-A-T, author authority, freshness |
 
 ---
 
-## Business Type Detection
+## Inline Artifact Policy
 
-Analyze homepage for patterns:
-
-| Type | Signals |
-|------|---------|
-| **SaaS** | Pricing page, "Sign up", "Free trial", "/app", "/dashboard", API docs |
-| **Local Service** | Phone number, address, "Near me", Google Maps embed, service area |
-| **E-commerce** | Product pages, cart, "Add to cart", price elements, product schema |
-| **Publisher** | Blog, articles, bylines, publication dates, article schema |
-| **Agency** | Portfolio, case studies, "Our services", client logos, testimonials |
-| **Other** | Default — apply general GEO best practices |
-
-Adjust recommendations based on detected type. Local businesses need LocalBusiness schema and Google Business Profile optimization. SaaS needs SoftwareApplication schema and comparison page strategy. E-commerce needs Product schema and review aggregation.
+Generated artefacts (llms.txt, JSON-LD snippets, robots.txt patches) are **displayed as
+code blocks in the conversation**. The user copies and deploys them. No file writes to disk
+unless explicitly requested.
 
 ---
 
-## Sub-Skills (13 Specialized Components)
+## Market Context
 
-| # | Skill | Directory | Purpose |
-|---|-------|-----------|---------|
-| 1 | geo-audit | `skills/geo-audit/` | Full audit orchestration and scoring |
-| 2 | geo-citability | `skills/geo-citability/` | Passage-level AI citation readiness |
-| 3 | geo-crawlers | `skills/geo-crawlers/` | AI crawler access and robots.txt |
-| 4 | geo-llmstxt | `skills/geo-llmstxt/` | llms.txt standard analysis and generation |
-| 5 | geo-brand-mentions | `skills/geo-brand-mentions/` | Brand presence on AI-cited platforms |
-| 6 | geo-platform-optimizer | `skills/geo-platform-optimizer/` | Platform-specific AI search optimization |
-| 7 | geo-schema | `skills/geo-schema/` | Structured data for AI discoverability |
-| 8 | geo-technical | `skills/geo-technical/` | Technical SEO foundations |
-| 9 | geo-content | `skills/geo-content/` | Content quality and E-E-A-T |
-| 10 | geo-report | `skills/geo-report/` | Client-ready deliverable generation |
-| 11 | geo-prospect | `skills/geo-prospect/` | CRM-lite prospect and client pipeline management |
-| 12 | geo-proposal | `skills/geo-proposal/` | Auto-generate client proposals from audit data |
-| 13 | geo-compare | `skills/geo-compare/` | Monthly delta tracking and progress reports |
-
----
-
-## Subagents (5 Parallel Workers)
-
-| Agent | File | Skills Used |
-|-------|------|-------------|
-| geo-ai-visibility | `agents/geo-ai-visibility.md` | geo-citability, geo-crawlers, geo-llmstxt, geo-brand-mentions |
-| geo-platform-analysis | `agents/geo-platform-analysis.md` | geo-platform-optimizer |
-| geo-technical | `agents/geo-technical.md` | geo-technical |
-| geo-content | `agents/geo-content.md` | geo-content |
-| geo-schema | `agents/geo-schema.md` | geo-schema |
-
----
-
-## Output Files
-
-All commands generate structured output:
-
-| Command | Output File |
-|---------|------------|
-| `/geo audit` | `GEO-AUDIT-REPORT.md` |
-| `/geo page` | `GEO-PAGE-ANALYSIS.md` |
-| `/geo citability` | `GEO-CITABILITY-SCORE.md` |
-| `/geo crawlers` | `GEO-CRAWLER-ACCESS.md` |
-| `/geo llmstxt` | `llms.txt` (ready to deploy) |
-| `/geo brands` | `GEO-BRAND-MENTIONS.md` |
-| `/geo platforms` | `GEO-PLATFORM-OPTIMIZATION.md` |
-| `/geo schema` | `GEO-SCHEMA-REPORT.md` + generated JSON-LD |
-| `/geo technical` | `GEO-TECHNICAL-AUDIT.md` |
-| `/geo content` | `GEO-CONTENT-ANALYSIS.md` |
-| `/geo report` | `GEO-CLIENT-REPORT.md` (presentation-ready) |
-| `/geo report-pdf` | `GEO-REPORT.pdf` (professional PDF with charts) |
-| `/geo quick` | Inline summary (no file) |
-| `/geo prospect` | Updates `~/.geo-prospects/prospects.json` |
-| `/geo proposal` | `~/.geo-prospects/proposals/<domain>-proposal-<date>.md` |
-| `/geo compare` | `~/.geo-prospects/reports/<domain>-monthly-<YYYY-MM>.md` |
-
----
-
-## PDF Report Generation
-
-The `/geo report-pdf <url>` command generates a professional, branded PDF report:
-
-### How It Works
-1. Run the full audit or individual analyses first
-2. Collect all scores and findings into a JSON structure
-3. Execute the PDF generator: `python3 ~/.claude/skills/geo/scripts/generate_pdf_report.py data.json GEO-REPORT.pdf`
-
-### What the PDF Includes
-- **Cover page** with GEO score gauge visualization
-- **Score breakdown** with color-coded bar charts
-- **AI Platform Readiness** dashboard with horizontal bar chart
-- **Crawler Access** status table with color-coded Allow/Block
-- **Key Findings** categorized by severity (Critical/High/Medium/Low)
-- **Prioritized Action Plan** (Quick Wins, Medium-Term, Strategic)
-- **Methodology & Glossary** appendix
-
-### Workflow
-1. First run `/geo audit <url>` to collect all data
-2. Then run `/geo report-pdf <url>` to generate the PDF
-3. The tool will compile audit data into JSON, then generate the PDF
-4. Output: `GEO-REPORT.pdf` in the current directory
+| Metric | Value |
+|---|---|
+| AI-referred session growth | +527% (Jan–May 2025, SparkToro) |
+| AI traffic conversion vs organic | 4.4x higher |
+| Google AI Overviews reach | 1.5B users/month |
+| ChatGPT weekly active users | 900M+ |
+| Perplexity monthly queries | 500M+ |
+| Brand mentions vs backlinks for AI | 3x stronger correlation (Ahrefs Dec 2025) |
 
 ---
 
 ## Quality Gates
 
-- **Crawl limit:** Max 50 pages per audit (focus on quality over quantity)
+- **Crawl limit:** Max 50 pages per audit
 - **Timeout:** 30 seconds per page fetch
-- **Rate limiting:** 1-second delay between requests, max 5 concurrent
-- **Robots.txt:** Always respect, always check
-- **Duplicate detection:** Skip pages with >80% content similarity
-
----
-
-## Quick Start Examples
-
-```
-# Full GEO audit of a website
-/geo audit https://example.com
-
-# Check if AI bots can see your site
-/geo crawlers https://example.com
-
-# Score a specific page for AI citability
-/geo citability https://example.com/blog/best-article
-
-# Generate an llms.txt file for your site
-/geo llmstxt https://example.com
-
-# Get a 60-second visibility snapshot
-/geo quick https://example.com
-
-# Generate a client-ready report
-/geo report https://example.com
-```
+- **Rate limiting:** 1-second delay between requests
+- **Robots.txt:** Always respect

--- a/references/workers/brand-mentions.md
+++ b/references/workers/brand-mentions.md
@@ -1,0 +1,32 @@
+# Worker: brand-mentions
+
+## ⚠️ STUB — see issue #3
+
+Detection capabilities are partial. Wikipedia and YouTube are functional.
+Reddit and LinkedIn use search fallbacks.
+
+## Task
+
+Measure off-site brand presence on AI-weighted platforms.
+
+1. Extract brand name from site homepage (title, OG tags, or H1).
+2. Run `node {baseDir}/scripts/brand-scanner.mjs --url <url> --brand "<name>"`.
+3. Score each platform using the rubric in `skills/geo-brand-mentions/SKILL.md`.
+4. Compute weighted Brand Authority Score.
+5. Identify the 3 most critical gaps.
+6. Identify the 3 highest-impact quick wins.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["No Wikipedia article — brand not an AI-recognised entity", "..."],
+  "quick_wins_3": ["Create Wikidata entity with official website and LinkedIn", "..."]
+}
+```
+
+## Depth Presets
+
+- **Full:** all platforms (YouTube, Reddit, Wikipedia, LinkedIn, supplementary)
+- **Quick:** Wikipedia + YouTube only (highest correlation with AI citation)

--- a/references/workers/citability.md
+++ b/references/workers/citability.md
@@ -1,0 +1,34 @@
+# Worker: citability
+
+## Task
+
+Analyse the target URL for passage-level AI citation readiness.
+
+1. Run `node {baseDir}/scripts/citability-scorer.mjs --url <url>`.
+2. Interpret the JSON output using the scoring rubric in `skills/geo-citability/SKILL.md`.
+3. Identify the 3 most critical issues affecting passage extractability.
+4. Identify the 3 highest-impact quick wins.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["specific issue with page URL if relevant", "..."],
+  "quick_wins_3": ["specific actionable fix", "..."]
+}
+```
+
+On fatal error (script fails, URL unreachable):
+```json
+{
+  "score": null,
+  "critical_3": ["Worker failed: <reason>"],
+  "quick_wins_3": []
+}
+```
+
+## Depth Presets
+
+- **Full:** analyse all sampled pages, score all content blocks
+- **Quick:** analyse homepage + 2 key pages only, score H2-level blocks only

--- a/references/workers/content.md
+++ b/references/workers/content.md
@@ -1,0 +1,27 @@
+# Worker: content
+
+## Task
+
+Evaluate E-E-A-T content quality at page level.
+
+1. Fetch homepage + 3 key content pages using `node {baseDir}/scripts/fetch-page.mjs --url <url>`.
+2. Score each page across Experience, Expertise, Authoritativeness, and Trustworthiness
+   using the rubric in `skills/geo-content/SKILL.md`.
+3. Assess topical authority modifier.
+4. Identify the 3 most critical E-E-A-T failures.
+5. Identify the 3 highest-impact quick wins.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["specific issue with page URL if relevant", "..."],
+  "quick_wins_3": ["specific actionable fix", "..."]
+}
+```
+
+## Depth Presets
+
+- **Full:** homepage + 5 content pages, full E-E-A-T rubric, topical authority modifier
+- **Quick:** homepage + 1 blog post, Experience and Expertise dimensions only

--- a/references/workers/crawlers.md
+++ b/references/workers/crawlers.md
@@ -1,0 +1,30 @@
+# Worker: crawlers
+
+## Task
+
+Map AI crawler access from robots.txt and page-level directives.
+
+1. Fetch `[domain]/robots.txt`.
+2. For each AI crawler in the reference table in `skills/geo-crawlers/SKILL.md`, determine
+   effective access: explicit Allow / explicit Disallow / wildcard inheritance.
+3. Sample 3 key pages for `<meta name="robots">` and `X-Robots-Tag` headers.
+4. Check for `noai`, `noimageai` directives.
+5. Check for `Sitemap:` directive.
+6. Score using the crawler access rubric.
+7. Identify the 3 most critical blocks (Tier 1 crawlers always rank as Critical).
+8. Generate specific robots.txt fix lines as quick wins.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["GPTBot blocked via User-agent: * Disallow: /", "..."],
+  "quick_wins_3": ["Add 'User-agent: GPTBot\\nAllow: /' to robots.txt", "..."]
+}
+```
+
+## Depth Presets
+
+- **Full:** full crawler reference table, meta tag + header checks on 3 pages
+- **Quick:** Tier 1 crawlers only, robots.txt only (skip meta/header checks)

--- a/references/workers/llmstxt.md
+++ b/references/workers/llmstxt.md
@@ -1,0 +1,30 @@
+# Worker: llmstxt
+
+## Task
+
+Validate existing llms.txt or generate a new one.
+
+1. Run `node {baseDir}/scripts/llmstxt-generator.mjs --mode validate --url <url>`.
+2. If file not found (score 0), run with `--mode generate` to produce a draft.
+3. Validate format against the checklist in `skills/geo-llmstxt/SKILL.md`.
+4. Score on Completeness × 0.40 + Accuracy × 0.35 + Usefulness × 0.25.
+5. Identify the 3 most critical issues.
+6. Quick wins: if file missing, emit generated llms.txt as code block.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["No llms.txt found at /llms.txt", "..."],
+  "quick_wins_3": ["Create /llms.txt using the generated template below", "..."]
+}
+```
+
+Generated llms.txt is emitted as a fenced code block in the orchestrator output,
+immediately following the quick wins for this worker.
+
+## Depth Presets
+
+- **Full:** validate + generate if missing, compare against full sitemap
+- **Quick:** validate only (or generate if missing), no sitemap cross-check

--- a/references/workers/platform-optimizer.md
+++ b/references/workers/platform-optimizer.md
@@ -1,0 +1,33 @@
+# Worker: platform-optimizer
+
+## ⚠️ STUB — see issue #2
+
+This worker's input contract is not yet defined. It currently returns estimated
+scores based on available worker inputs.
+
+## Task (when fully implemented)
+
+Interpret the combined scores from all other workers to produce per-platform readiness
+assessments for:
+- Google AI Overviews
+- ChatGPT Web Search
+- Perplexity AI
+- Google Gemini
+- Bing Copilot
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["platform-specific critical issue", "..."],
+  "quick_wins_3": ["platform-specific quick win", "..."]
+}
+```
+
+Score is the average of the 5 platform scores.
+
+## Depth Presets
+
+- **Full:** all 5 platforms
+- **Quick:** Google AIO + ChatGPT only (highest traffic impact)

--- a/references/workers/schema.md
+++ b/references/workers/schema.md
@@ -1,0 +1,35 @@
+# Worker: schema
+
+## Task
+
+Detect, validate, and assess JSON-LD structured data.
+
+1. Fetch homepage + 2 inner pages raw HTML using
+   `node {baseDir}/scripts/fetch-page.mjs --url <url>`.
+2. Parse all `<script type="application/ld+json">` blocks.
+3. Validate each block: valid JSON, valid `@type`, required properties present,
+   sameAs links resolve.
+4. Flag JS-injected schema (not in server-rendered HTML).
+5. Flag deprecated schemas (SpecialAnnouncement, HowTo rich results, old VideoObject).
+6. Assess sameAs coverage: how many platform URLs are linked?
+7. Score using the rubric in `skills/geo-schema/SKILL.md`.
+8. Identify the 3 most critical gaps.
+9. Generate missing JSON-LD as quick wins.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["specific gap with page URL", "..."],
+  "quick_wins_3": ["Add Organization JSON-LD with sameAs...", "..."]
+}
+```
+
+Quick wins that include generated JSON-LD: emit the code block inline in the
+orchestrator output, after the score summary.
+
+## Depth Presets
+
+- **Full:** homepage + 3 pages, all schema types, sameAs audit
+- **Quick:** homepage only, Organization + Article presence check

--- a/references/workers/technical.md
+++ b/references/workers/technical.md
@@ -1,0 +1,29 @@
+# Worker: technical
+
+## Task
+
+Audit technical SEO health with GEO-specific focus.
+
+1. Fetch `[domain]/robots.txt`.
+2. Fetch homepage raw HTML using `node {baseDir}/scripts/fetch-page.mjs --url <url>`.
+3. Check HTTP response headers for security directives.
+4. Assess SSR status: compare raw HTML content to expected rendered output.
+5. Estimate Core Web Vitals from page characteristics (LCP element, JS bundle size, image formats, explicit dimensions).
+6. Score all 8 categories using the rubric in `skills/geo-technical/SKILL.md`.
+7. Identify the 3 most critical issues. SSR failures and AI crawler blocks always rank as Critical.
+8. Identify the 3 highest-impact quick wins.
+
+## Return
+
+```json
+{
+  "score": 0-100,
+  "critical_3": ["specific issue", "..."],
+  "quick_wins_3": ["specific fix", "..."]
+}
+```
+
+## Depth Presets
+
+- **Full:** homepage + 3 inner pages, all 8 categories
+- **Quick:** homepage only, SSR check + AI crawler access + HTTPS only

--- a/skills/geo-audit/SKILL.md
+++ b/skills/geo-audit/SKILL.md
@@ -1,337 +1,160 @@
 ---
 name: geo-audit
-description: Full website GEO+SEO audit with parallel subagent delegation. Orchestrates a comprehensive Generative Engine Optimization audit across AI citability, platform analysis, technical infrastructure, content quality, and schema markup. Produces a composite GEO Score (0-100) with prioritized action plan.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - WebFetch
-  - Write
+description: >
+  Full GEO audit orchestrator. Launches 8 parallel analysis workers, collects their
+  results, computes a composite GEO Score (0-100), and outputs a prioritised action
+  plan. Use for /geo audit and /geo quick. Does NO direct analysis — delegates everything
+  to specialised workers.
 ---
 
-# GEO Audit Orchestration Skill
+# GEO Audit Orchestrator
 
 ## Purpose
 
-This skill performs a comprehensive Generative Engine Optimization (GEO) audit of any website. GEO is the practice of optimizing web content so that AI systems (ChatGPT, Claude, Perplexity, Gemini, etc.) can discover, understand, cite, and recommend it. This audit measures how well a site performs across all GEO dimensions and produces an actionable improvement plan.
-
-## Key Insight
-
-Traditional SEO optimizes for search engine rankings. GEO optimizes for AI citation and recommendation. Sites that score high on GEO metrics see 30-115% more visibility in AI-generated responses (Georgia Tech / Princeton / IIT Delhi 2024 study). The two disciplines overlap but have distinct requirements.
+This skill is the orchestration layer. It runs all 8 analysis workers in parallel and
+synthesises their outputs into a single composite GEO Score with a prioritised action plan.
+It never performs analysis itself.
 
 ---
 
-## Audit Workflow
+## Orchestration Flow
 
-### Phase 1: Discovery and Reconnaissance
+### Phase 1: Discovery (Sequential)
 
-**Step 1: Fetch Homepage and Detect Business Type**
+1. Fetch homepage HTML using `scripts/fetch-page.mjs`.
+2. Detect business type from page signals:
 
-1. Use WebFetch to retrieve the homepage at the provided URL.
-2. Extract the following signals:
-   - Page title, meta description, H1 heading
-   - Navigation menu items (reveals site structure)
-   - Footer content (reveals business info, location, legal pages)
-   - Schema.org markup on homepage (Organization, LocalBusiness, etc.)
-   - Pricing page link (SaaS indicator)
-   - Product listing patterns (E-commerce indicator)
-   - Blog/resource section (Publisher indicator)
-   - Service pages (Agency indicator)
-   - Address/phone/Google Maps embed (Local business indicator)
-
-3. Classify the business type using these patterns:
-
-| Business Type | Detection Signals |
+| Type | Signals |
 |---|---|
-| **SaaS** | Pricing page, "Sign up" / "Free trial" CTAs, app.domain.com subdomain, feature comparison tables, integration pages |
-| **Local Business** | Physical address on homepage, Google Maps embed, "Near me" content, LocalBusiness schema, service area pages |
-| **E-commerce** | Product listings, shopping cart, product schema, category pages, price displays, "Add to cart" buttons |
-| **Publisher** | Blog-heavy navigation, article schema, author pages, date-based archives, RSS feeds, high content volume |
-| **Agency/Services** | Case studies, portfolio, "Our Work" section, team page, client logos, service descriptions |
-| **Hybrid** | Combination of above signals -- classify by dominant pattern |
+| SaaS | Pricing page, "Sign up" / "Free trial" CTAs, `/app` or `/dashboard` subdomain |
+| Local | Physical address, Google Maps embed, service area pages |
+| E-commerce | Product listings, shopping cart, price displays |
+| Publisher | Blog-heavy nav, article schema, author pages, bylines |
+| Agency | Case studies, portfolio, team page, client logos |
+| Other | Default |
 
-**Step 2: Crawl Sitemap and Internal Links**
-
-1. Attempt to fetch `/sitemap.xml` and `/sitemap_index.xml`.
-2. If sitemap exists, extract up to 50 unique page URLs prioritized by:
-   - Homepage (always include)
+3. Extract up to 50 page URLs from `/sitemap.xml` or internal links. Priority:
+   - Homepage (always)
    - Top-level navigation pages
-   - High-value pages (pricing, about, contact, key service/product pages)
-   - Blog posts (sample 5-10 most recent)
-   - Category/landing pages
-3. If no sitemap exists, crawl internal links from the homepage:
-   - Extract all `<a href>` links pointing to the same domain
-   - Follow up to 2 levels deep
-   - Prioritize pages linked from main navigation
-4. Respect `robots.txt` directives -- do not fetch disallowed paths.
-5. Enforce a maximum of 50 pages and a 30-second timeout per fetch.
+   - Key service/product/pricing pages
+   - 5–10 most recent blog posts
+4. Respect `robots.txt` — do not fetch disallowed paths.
 
-**Step 3: Collect Page-Level Data**
+### Phase 2: Parallel Workers
 
-For each page in the crawl set, record:
-- URL, title, meta description, canonical URL
-- H1-H6 heading structure
-- Word count of main content
-- Schema.org types present
-- Internal/external link counts
-- Images with/without alt text
-- Open Graph and Twitter Card meta tags
-- Response status code
-- Whether the page has structured data
+Launch all 8 workers simultaneously. Worker task specs are in `references/workers/`.
 
----
-
-### Phase 2: Parallel Subagent Delegation
-
-Delegate analysis to 5 specialized subagents. Each subagent operates on the collected page data and produces a category score (0-100) plus findings.
-
-**Subagent 1: AI Visibility Analysis (geo-ai-visibility)**
-- Analyze content blocks for quotability by AI systems (citability scoring)
-- Check AI crawler access via robots.txt and llms.txt presence
-- Scan brand presence across YouTube, Reddit, Wikipedia, LinkedIn
-- Score brand authority signals that AI models use for entity recognition
-
-**Subagent 2: Platform Optimization (geo-platform-analysis)**
-- Assess readiness for Google AI Overviews, ChatGPT, Perplexity, Gemini, Bing Copilot
-- Check platform-specific ranking factors and optimization opportunities
-
-**Subagent 3: Technical GEO Infrastructure (geo-technical)**
-- Analyze robots.txt for AI crawler access
-- Verify meta tags, headers, and technical accessibility for AI systems
-- Check page speed, server-side rendering, and Core Web Vitals
-- Assess security headers and mobile optimization
-
-**Subagent 4: Content E-E-A-T Quality (geo-content)**
-- Evaluate Experience, Expertise, Authoritativeness, Trustworthiness signals
-- Check author bios, credentials, source citations
-- Assess content freshness, depth, and originality
-- Verify "About" page quality and team credentials
-
-**Subagent 5: Schema & Structured Data (geo-schema)**
-- Validate all schema.org markup
-- Check for GEO-critical schema types (FAQ, HowTo, Organization, Product, Article)
-- Assess schema completeness and accuracy
-- Identify missing schema opportunities
-
----
-
-### Phase 3: Score Aggregation and Report Generation
-
-#### Composite GEO Score Calculation
-
-The overall GEO Score (0-100) is a weighted average of six category scores:
-
-| Category | Weight | What It Measures |
+| Worker | Worker spec file | Domain |
 |---|---|---|
-| **AI Citability** | 25% | How quotable/extractable content is for AI systems |
-| **Brand Authority** | 20% | Third-party mentions, entity recognition signals |
-| **Content E-E-A-T** | 20% | Experience, Expertise, Authoritativeness, Trustworthiness |
-| **Technical GEO** | 15% | AI crawler access, llms.txt, rendering, speed |
-| **Schema & Structured Data** | 10% | Schema.org markup quality and completeness |
-| **Platform Optimization** | 10% | Presence on platforms AI models train on and cite |
+| citability | `references/workers/citability.md` | Passage-level citation readiness |
+| content | `references/workers/content.md` | E-E-A-T, author authority, freshness |
+| technical | `references/workers/technical.md` | Core Web Vitals, SSR, mobile |
+| crawlers | `references/workers/crawlers.md` | robots.txt AI crawler access |
+| schema | `references/workers/schema.md` | JSON-LD detection, validation |
+| llmstxt | `references/workers/llmstxt.md` | llms.txt presence, validity |
+| platform-optimizer | `references/workers/platform-optimizer.md` | Platform score interpretation (STUB) |
+| brand-mentions | `references/workers/brand-mentions.md` | Off-site brand signals (STUB) |
 
-**Formula:**
-```
-GEO_Score = (Citability * 0.25) + (Brand * 0.20) + (EEAT * 0.20) + (Technical * 0.15) + (Schema * 0.10) + (Platform * 0.10)
+Each worker returns:
+```json
+{
+  "score": 0-100,
+  "critical_3": ["issue 1", "issue 2", "issue 3"],
+  "quick_wins_3": ["win 1", "win 2", "win 3"]
+}
 ```
 
-#### Score Interpretation
+If a worker fails (timeout, blocked, parse error):
+```json
+{
+  "score": null,
+  "critical_3": ["Worker failed: <reason>"],
+  "quick_wins_3": []
+}
+```
 
-| Score Range | Rating | Interpretation |
+### Phase 3: Synthesis
+
+**Composite GEO Score:**
+```
+GEO_Score = (citability * 0.25) + (brand * 0.20) + (content * 0.20)
+          + (technical * 0.15) + (schema * 0.10) + (platform * 0.10)
+```
+
+Workers with `score: null` are excluded from the weighted average; weights are
+redistributed proportionally across available scores.
+
+**Merged critical issues:** Combine all `critical_3` arrays, deduplicate, re-rank by
+severity. Output top 5.
+
+**Merged quick wins:** Combine all `quick_wins_3` arrays, deduplicate, re-rank by
+impact-to-effort ratio. Output top 5.
+
+---
+
+## Depth Presets
+
+| Command | Preset | Behaviour |
 |---|---|---|
-| 90-100 | Excellent | Top-tier GEO optimization; site is highly likely to be cited by AI |
-| 75-89 | Good | Strong GEO foundation with room for improvement |
-| 60-74 | Fair | Moderate GEO presence; significant optimization opportunities exist |
-| 40-59 | Poor | Weak GEO signals; AI systems may struggle to cite or recommend |
-| 0-39 | Critical | Minimal GEO optimization; site is largely invisible to AI systems |
+| `/geo audit <url>` | Full | All workers, full checks, up to 50 pages |
+| `/geo quick <url>` | Quick | Same workers, shallower: max 5 pages, 3 citability samples, skip slow external lookups |
+
+Same output structure for both. Quick omits the 30-day action plan section.
 
 ---
 
-## Issue Severity Classification
+## Score Interpretation
 
-Every issue found during the audit is classified by severity:
-
-### Critical (Fix Immediately)
-- All AI crawlers blocked in robots.txt
-- No indexable content (JavaScript-rendered only with no SSR)
-- Domain-level noindex directive
-- Site returns 5xx errors on key pages
-- Complete absence of any structured data
-- Brand not recognized as an entity by any AI system
-
-### High (Fix Within 1 Week)
-- Key AI crawlers (GPTBot, ClaudeBot, PerplexityBot) blocked
-- No llms.txt file present
-- Zero question-answering content blocks on key pages
-- Missing Organization or LocalBusiness schema
-- No author attribution on content pages
-- All content behind login/paywall with no preview
-
-### Medium (Fix Within 1 Month)
-- Partial AI crawler blocking (some allowed, some blocked)
-- llms.txt exists but is incomplete or malformed
-- Content blocks average under 50 citability score
-- Missing FAQ schema on pages with FAQ content
-- Thin author bios without credentials
-- No Wikipedia or Reddit brand presence
-
-### Low (Optimize When Possible)
-- Minor schema validation errors
-- Some images missing alt text
-- Content freshness issues on non-critical pages
-- Missing Open Graph tags
-- Suboptimal heading hierarchy on some pages
-- LinkedIn company page exists but is incomplete
+| Range | Rating |
+|---|---|
+| 90–100 | Excellent — top-tier GEO; highly likely to be cited by AI |
+| 75–89 | Good — strong foundation, specific gaps to address |
+| 60–74 | Fair — moderate GEO presence, significant opportunities |
+| 40–59 | Poor — weak signals; AI may not recognise the site as citable |
+| 0–39 | Critical — minimal optimisation; largely invisible to AI |
 
 ---
 
-## Output Format
+## Output Format (inline, no file writes)
 
-Generate a file called `GEO-AUDIT-REPORT.md` with the following structure:
+```
+# GEO Audit: [Site Name]
+Date: [Date] | URL: [URL] | Business Type: [Type] | Pages analysed: [N]
 
-```markdown
-# GEO Audit Report: [Site Name]
+## Overall GEO Score: [X]/100 ([Rating])
 
-**Audit Date:** [Date]
-**URL:** [URL]
-**Business Type:** [Detected Type]
-**Pages Analyzed:** [Count]
-
----
-
-## Executive Summary
-
-**Overall GEO Score: [X]/100 ([Rating])**
-
-[2-3 sentence summary of the site's GEO health, biggest strengths, and most critical gaps.]
+[2-3 sentence executive summary]
 
 ### Score Breakdown
-
-| Category | Score | Weight | Weighted Score |
+| Category        | Score   | Weight | Weighted |
 |---|---|---|---|
-| AI Citability | [X]/100 | 25% | [X] |
-| Brand Authority | [X]/100 | 20% | [X] |
-| Content E-E-A-T | [X]/100 | 20% | [X] |
-| Technical GEO | [X]/100 | 15% | [X] |
-| Schema & Structured Data | [X]/100 | 10% | [X] |
-| Platform Optimization | [X]/100 | 10% | [X] |
-| **Overall GEO Score** | | | **[X]/100** |
+| AI Citability   | [X]/100 | 25%    | [X]      |
+| Brand Authority | [X]/100 | 20%    | [X]      |
+| Content E-E-A-T | [X]/100 | 20%    | [X]      |
+| Technical GEO   | [X]/100 | 15%    | [X]      |
+| Schema          | [X]/100 | 10%    | [X]      |
+| Platform Optim. | [X]/100 | 10%    | [X]      |
+| **Overall**     |         |        | **[X]**  |
 
----
+## Top Critical Issues
+1. [Issue — specific, with page URL where relevant]
+2. [Issue]
+3. [Issue]
+4. [Issue]
+5. [Issue]
 
-## Critical Issues (Fix Immediately)
+## Top Quick Wins
+1. [Specific, actionable, single-sentence]
+2. [Win]
+3. [Win]
+4. [Win]
+5. [Win]
 
-[List each critical issue with specific page URLs and recommended fix]
-
-## High Priority Issues
-
-[List each high-priority issue with details]
-
-## Medium Priority Issues
-
-[List each medium-priority issue]
-
-## Low Priority Issues
-
-[List each low-priority issue]
-
----
-
-## Category Deep Dives
-
-### AI Citability ([X]/100)
-[Detailed findings, examples of good/bad passages, rewrite suggestions]
-
-### Brand Authority ([X]/100)
-[Platform presence map, mention volume, sentiment]
-
-### Content E-E-A-T ([X]/100)
-[Author quality, source citations, freshness, depth]
-
-### Technical GEO ([X]/100)
-[Crawler access, llms.txt, rendering, headers]
-
-### Schema & Structured Data ([X]/100)
-[Schema types found, validation results, missing opportunities]
-
-### Platform Optimization ([X]/100)
-[Presence on YouTube, Reddit, Wikipedia, etc.]
-
----
-
-## Quick Wins (Implement This Week)
-
-1. [Specific, actionable quick win with expected impact]
-2. [Another quick win]
-3. [Another quick win]
-4. [Another quick win]
-5. [Another quick win]
-
-## 30-Day Action Plan
-
+## 30-Day Action Plan (Full audit only)
 ### Week 1: [Theme]
-- [ ] Action item 1
-- [ ] Action item 2
+- [ ] Action
+- [ ] Action
 
 ### Week 2: [Theme]
-- [ ] Action item 1
-- [ ] Action item 2
-
-### Week 3: [Theme]
-- [ ] Action item 1
-- [ ] Action item 2
-
-### Week 4: [Theme]
-- [ ] Action item 1
-- [ ] Action item 2
-
----
-
-## Appendix: Pages Analyzed
-
-| URL | Title | GEO Issues |
-|---|---|---|
-| [url] | [title] | [issue count] |
+...
 ```
-
----
-
-## Quality Gates
-
-- **Page Limit:** Never crawl more than 50 pages per audit. Prioritize high-value pages.
-- **Timeout:** 30-second maximum per page fetch. Skip pages that exceed this.
-- **Robots.txt:** Always check and respect robots.txt before crawling. Note any AI-specific directives.
-- **Rate Limiting:** Wait at least 1 second between page fetches to avoid overloading the server.
-- **Error Handling:** Log failed fetches but continue the audit. Report fetch failures in the appendix.
-- **Content Type:** Only analyze HTML pages. Skip PDFs, images, and other binary content.
-- **Deduplication:** Canonicalize URLs before crawling. Skip duplicate content (e.g., HTTP vs HTTPS, www vs non-www, trailing slashes).
-
----
-
-## Business-Type-Specific Audit Adjustments
-
-### SaaS Sites
-- Extra weight on: Feature comparison tables (high citability), integration pages, documentation quality
-- Check for: API documentation structure, changelog pages, knowledge base organization
-- Key schema: SoftwareApplication, FAQPage, HowTo
-
-### Local Businesses
-- Extra weight on: NAP consistency, Google Business Profile signals, local schema
-- Check for: Service area pages, location-specific content, review markup
-- Key schema: LocalBusiness, GeoCoordinates, OpeningHoursSpecification
-
-### E-commerce Sites
-- Extra weight on: Product descriptions (citability), comparison content, buying guides
-- Check for: Product schema completeness, review aggregation, FAQ sections on product pages
-- Key schema: Product, AggregateRating, Offer, BreadcrumbList
-
-### Publishers
-- Extra weight on: Article quality, author credentials, source citation practices
-- Check for: Article schema, author pages, publication date freshness, original research
-- Key schema: Article, NewsArticle, Person (author), ClaimReview
-
-### Agency/Services
-- Extra weight on: Case studies (citability), expertise demonstration, thought leadership
-- Check for: Portfolio schema, team credentials, industry-specific expertise signals
-- Key schema: Organization, Service, Person (team), Review

--- a/skills/geo-brand-mentions/SKILL.md
+++ b/skills/geo-brand-mentions/SKILL.md
@@ -1,480 +1,122 @@
 ---
 name: geo-brand-mentions
-description: Brand mention and authority scanner for AI visibility. Analyzes brand presence across platforms that AI models rely on for entity recognition and citation decisions. Produces a Brand Authority Score (0-100) with platform-specific recommendations.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - WebFetch
-  - Write
+description: >
+  Off-site brand presence scanner. Checks brand visibility across YouTube, Reddit,
+  Wikipedia/Wikidata, and LinkedIn — the platforms AI systems weight most for entity
+  recognition and citation decisions. STUB: Wikipedia API and YouTube detection are
+  functional; Reddit and LinkedIn require search fallbacks. See issue #3.
 ---
 
-# Brand Mention Scanner Skill
+# GEO Brand Mentions Scanner
 
-## Core Insight
+## Purpose
 
-Brand mentions correlate approximately 3x more strongly with AI visibility than traditional backlinks. An Ahrefs study published in December 2025, analyzing 75,000 brands across AI search platforms, found that **unlinked brand mentions** -- references to a brand name without a hyperlink -- are a stronger predictor of whether AI systems cite and recommend a brand than Domain Rating or backlink count.
+Measure off-site brand signals that AI systems use for entity recognition and citation
+decisions. Brand mentions on high-signal platforms (YouTube, Reddit, Wikipedia) correlate
+3× more strongly with AI visibility than traditional backlinks (Ahrefs Dec 2025, 75K brands).
 
-The critical finding: **the platform where the mention appears matters enormously.** Not all mentions are equal. A mention on YouTube or Reddit carries far more weight for AI citation than a mention on a low-authority blog, because AI training data and retrieval systems disproportionately index high-engagement platforms.
-
-This inverts a core assumption of traditional SEO. In traditional SEO, a backlink from a high-DR site is the gold standard. In GEO, an unlinked mention on Reddit or a YouTube video description may be more valuable than a dofollow backlink from a DR 70 blog.
-
----
-
-## Platform Importance Ranking for AI Citations
-
-Based on the Ahrefs December 2025 study and corroborating research from Profound (2025) and Terakeet (2025):
-
-### 1. YouTube Mentions -- Correlation ~0.737 (STRONGEST)
-
-**Why YouTube matters most:**
-- YouTube is the second-largest search engine and the largest video platform globally (2.5B+ monthly users).
-- AI training datasets heavily incorporate YouTube transcripts, descriptions, and metadata.
-- Google's Gemini and AI Overviews directly reference YouTube content.
-- Perplexity and ChatGPT both index and cite YouTube video content.
-- YouTube transcripts are particularly valuable because they contain natural language mentions in conversational context, which aligns with how AI models process and generate text.
-
-**What to check:**
-- **Brand YouTube channel:** Does the brand have an active YouTube channel? How many subscribers? Video count? Upload frequency?
-- **Third-party video mentions:** Are other YouTubers or channels mentioning the brand? In what context (reviews, tutorials, comparisons)?
-- **Video descriptions:** Does the brand name appear in video descriptions of industry-relevant content?
-- **Video transcripts:** Is the brand mentioned in spoken content of relevant videos? (AI models index transcripts)
-- **YouTube search presence:** When searching "[brand name]" on YouTube, do results appear? Are they positive?
-- **Comment mentions:** Is the brand mentioned in comments on relevant industry videos?
-
-**Scoring for YouTube (0-100):**
-
-| Score | Criteria |
-|---|---|
-| 90-100 | Active channel with 10K+ subscribers, regular uploads, brand mentioned in 20+ third-party videos, appears in YouTube search results for industry terms |
-| 70-89 | Active channel with 1K+ subscribers, brand mentioned in 10-19 third-party videos, some YouTube search presence |
-| 50-69 | Channel exists with some content, brand mentioned in 5-9 third-party videos, limited YouTube search presence |
-| 30-49 | Channel exists but inactive, brand mentioned in 1-4 third-party videos |
-| 10-29 | No channel or empty channel, brand mentioned in 1-2 videos only |
-| 0-9 | No YouTube presence whatsoever |
+**This worker's domain:** off-site brand signals only.
+On-site E-E-A-T and author authority are handled by `geo-content`.
+Platform-specific AI search optimisation is handled by `geo-platform-optimizer`.
 
 ---
 
-### 2. Reddit Mentions -- High Correlation
+## ⚠️ STUB STATUS
 
-**Why Reddit matters:**
-- Reddit is one of the most heavily indexed platforms in AI training data (confirmed in Google's $60M/year Reddit licensing deal, 2024).
-- AI systems heavily weight Reddit for product recommendations, comparisons, and user sentiment.
-- "Reddit" is now appended to an estimated 10-15% of Google searches by users seeking authentic opinions.
-- Perplexity frequently cites Reddit threads as sources.
-- ChatGPT and Claude both reference Reddit discussions when answering product/service questions.
+This worker is partially implemented. Current detection capabilities:
 
-**What to check:**
-- **Subreddit presence:** Is the brand discussed in relevant subreddits? Which ones?
-- **Mention volume:** How many Reddit threads mention the brand? What is the trend (increasing/decreasing)?
-- **Sentiment:** Are mentions mostly positive, negative, or neutral? What are common praise points and complaints?
-- **Official presence:** Does the brand have an official Reddit account? Do they participate in discussions? Have they done AMAs?
-- **Recommendation threads:** Does the brand appear in "What do you recommend for X?" threads? Is it the top recommendation or an also-ran?
-- **Subreddit community:** Does the brand have its own subreddit? How active is it?
-
-**Scoring for Reddit (0-100):**
-
-| Score | Criteria |
-|---|---|
-| 90-100 | Frequently recommended in relevant subreddits, predominantly positive sentiment, active official presence, own subreddit with 5K+ members, appears in top recommendations for industry queries |
-| 70-89 | Regularly mentioned in relevant subreddits, mostly positive sentiment, some official presence, appears in multiple recommendation threads |
-| 50-69 | Mentioned in several relevant threads, mixed sentiment, brand name is recognized by community members |
-| 30-49 | Occasional mentions, limited to 1-2 subreddits, no official presence |
-| 10-29 | Rare mentions, brand largely unknown on Reddit |
-| 0-9 | No Reddit presence |
-
----
-
-### 3. Wikipedia Presence -- High Correlation
-
-**Why Wikipedia matters:**
-- Wikipedia is one of the highest-authority sources in AI training data. All major AI models have been trained on Wikipedia dumps.
-- AI systems use Wikipedia as a primary source for entity recognition -- determining whether a brand is a "real" entity worth knowing about.
-- Wikidata (Wikipedia's structured data sibling) provides machine-readable facts that AI models use for knowledge graph construction.
-- Having a Wikipedia page is a strong signal of notability, which correlates with AI systems treating the brand as an authoritative entity.
-
-**What to check:**
-- **Wikipedia page:** Does the brand or company have its own Wikipedia article? Is it marked for deletion or quality issues?
-- **Founder page:** Does the founder/CEO have a Wikipedia page? (Strong authority signal)
-- **Wikipedia citations:** Is the brand's website cited as a reference in any Wikipedia articles?
-- **Wikidata entry:** Does the brand have a Wikidata item (Q-number)? How complete is it?
-- **Wikipedia mentions:** Is the brand mentioned in other Wikipedia articles (industry articles, competitor pages, category pages)?
-- **Article quality:** If a Wikipedia page exists, is it a stub, start-class, or higher quality?
-
-**Scoring for Wikipedia (0-100):**
-
-| Score | Criteria |
-|---|---|
-| 90-100 | Detailed Wikipedia article (B-class or higher), Wikidata entry with complete properties, brand cited as reference in multiple articles, founder has Wikipedia page |
-| 70-89 | Wikipedia article exists (start-class or higher), Wikidata entry exists, brand mentioned in 2+ other Wikipedia articles |
-| 50-69 | Wikipedia article exists (stub or start), basic Wikidata entry, limited mentions in other articles |
-| 30-49 | No Wikipedia article but brand is mentioned in other articles or cited as reference; Wikidata entry may exist |
-| 10-29 | Brand mentioned in 1-2 Wikipedia articles as a passing reference only |
-| 0-9 | No Wikipedia or Wikidata presence of any kind |
-
----
-
-### 4. LinkedIn Presence -- Moderate Correlation
-
-**Why LinkedIn matters:**
-- LinkedIn content is increasingly indexed by AI systems for professional and B2B context.
-- Company LinkedIn pages and employee thought leadership posts build brand entity signals.
-- AI models reference LinkedIn for company information, team credentials, and professional authority.
-- LinkedIn articles and posts are indexed by search engines and AI crawlers.
-
-**What to check:**
-- **Company page:** Does the brand have a LinkedIn company page? Follower count? Post frequency?
-- **Employee thought leadership:** Are employees (especially leadership) posting thought leadership content that mentions the brand?
-- **Company mentions:** Is the brand mentioned in LinkedIn posts by non-employees? Industry analysts? Customers?
-- **LinkedIn articles:** Are there long-form LinkedIn articles about or mentioning the brand?
-- **Employee profiles:** Do employees list the company with detailed descriptions? Do they have strong professional profiles?
-- **Engagement metrics:** What is the typical engagement (likes, comments, shares) on company posts?
-
-**Scoring for LinkedIn (0-100):**
-
-| Score | Criteria |
-|---|---|
-| 90-100 | Active company page with 10K+ followers, leadership regularly posts thought leadership, brand frequently mentioned by industry professionals, strong employee profiles |
-| 70-89 | Active company page with 5K+ followers, some employee thought leadership, occasional third-party mentions |
-| 50-69 | Company page exists with 1K+ followers, irregular posting, limited third-party mentions |
-| 30-49 | Company page exists but is sparse or inactive, few followers, no third-party mentions |
-| 10-29 | Basic company page with minimal information |
-| 0-9 | No LinkedIn company page |
-
----
-
-### 5. Other Platform Presence -- Supplementary
-
-These platforms have lower but still meaningful correlation with AI visibility:
-
-#### Quora
-- **Relevance:** Quora answers are frequently included in AI training data and cited by Perplexity.
-- **What to check:** Is the brand mentioned in Quora answers to industry-relevant questions? Does the brand have an official Quora presence?
-- **Signal strength:** Moderate for B2C, lower for B2B.
-
-#### Stack Overflow / Stack Exchange
-- **Relevance:** Critical for developer-facing brands (SaaS, dev tools, APIs).
-- **What to check:** Is the brand's product discussed in Stack Overflow questions/answers? Does the brand have a tag? Do they have an official account answering questions?
-- **Signal strength:** High for technical products, irrelevant for most B2C.
-
-#### GitHub
-- **Relevance:** Critical for open-source and developer-focused brands.
-- **What to check:** Does the brand have a GitHub organization? Stars on repositories? Mentions in other repos' documentation or discussions?
-- **Signal strength:** High for dev tools and open-source, low for non-technical brands.
-
-#### Industry Forums and Communities
-- **Relevance:** Niche authority signals that AI models pick up from domain-specific training data.
-- **What to check:** Is the brand discussed in industry-specific forums (e.g., Hacker News for tech, ProductHunt for startups, industry-specific Slack communities)?
-- **Signal strength:** Moderate, but valuable for establishing niche authority.
-
-#### News and Press
-- **Relevance:** News mentions build entity authority and recency signals.
-- **What to check:** Has the brand been covered by major news outlets or industry publications? How recently? What was the context?
-- **Signal strength:** Moderate. Recency matters -- a mention in the last 6 months is far more valuable than one from 3 years ago.
-
-#### Podcasts
-- **Relevance:** Growing AI training data source. Transcripts are increasingly indexed.
-- **What to check:** Has the brand or its leadership appeared on podcasts? Are podcast transcripts mentioning the brand indexed by search engines?
-- **Signal strength:** Moderate and growing.
-
----
-
-## Composite Brand Authority Score
-
-### Scoring Formula
-
-| Platform | Weight | Rationale |
+| Platform | Detection Method | Status |
 |---|---|---|
-| YouTube Presence | 25% | Strongest correlation with AI citation (0.737) |
-| Reddit Presence | 25% | Second strongest correlation; critical for product recommendations |
-| Wikipedia / Wikidata | 20% | Entity recognition foundation; AI training data cornerstone |
-| LinkedIn Authority | 15% | Professional authority signals; B2B relevance |
-| Other Platforms | 15% | Supplementary signals from Quora, GitHub, news, forums, podcasts |
+| Wikipedia | Wikipedia API + Wikidata API | ✅ Functional |
+| YouTube | Channel URL pattern check | ✅ Functional |
+| Reddit | Web search fallback | ⚠️ Approximate |
+| LinkedIn | Web search fallback | ⚠️ Approximate |
 
-**Formula:**
-```
-Brand_Authority_Score = (YouTube * 0.25) + (Reddit * 0.25) + (Wikipedia * 0.20) + (LinkedIn * 0.15) + (Other * 0.15)
-```
-
-### Score Interpretation
-
-| Score Range | Rating | Interpretation |
-|---|---|---|
-| 85-100 | Dominant | Brand is a well-recognized entity across AI platforms. Highly likely to be cited and recommended by AI systems. |
-| 70-84 | Strong | Brand has solid cross-platform presence. AI systems likely recognize and cite it for relevant queries. |
-| 50-69 | Moderate | Brand has presence on some platforms but gaps exist. AI citation is inconsistent. |
-| 30-49 | Weak | Brand has limited platform presence. AI systems may not recognize it as a distinct entity. |
-| 0-29 | Minimal | Brand has negligible platform presence. AI systems are unlikely to cite or recommend it. |
+See issue #3 for the full detection model design decision.
 
 ---
 
-## Analysis Procedure
+## Script
 
-### Step 1: Identify Brand Information
-
-Gather the following from the user or from the website:
-- **Brand name** (exact spelling, including any official variants)
-- **Founder/CEO name(s)**
-- **Domain URL**
-- **Industry/category**
-- **Key products or services** (top 3)
-- **Key competitors** (for comparison context)
-
-### Step 2: Platform Scanning
-
-For each platform, use WebFetch to search and assess presence:
-
-**YouTube Check:**
-1. Search: `[brand name] site:youtube.com`
-2. Check: `youtube.com/@[brand-name]` or `youtube.com/c/[brand-name]` for official channel
-3. Search: `"[brand name]" site:youtube.com` (exact match for mentions in descriptions)
-4. Note: Channel subscriber count, video count, latest upload date, third-party mention count
-
-**Reddit Check:**
-1. Search: `[brand name] site:reddit.com`
-2. Search: `"[brand name]" site:reddit.com` (exact match)
-3. Check: `reddit.com/r/[brand-name]` for official subreddit
-4. Check: `reddit.com/user/[brand-name]` for official account
-5. Note: Thread count, dominant subreddits, sentiment (positive/negative/neutral), recommendation frequency
-
-**Wikipedia Check (IMPORTANT — use BOTH methods to avoid false negatives):**
-
-**Method 1 — Python API check (MOST RELIABLE, do this FIRST):**
 ```bash
-python3 -c "
-import requests, json
-from urllib.parse import quote_plus
-brand = '[Brand_Name]'
-# Check Wikipedia API directly
-api_url = f'https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch={quote_plus(brand)}&format=json'
-r = requests.get(api_url, headers={'User-Agent': 'GEO-Audit/1.0'}, timeout=15)
-data = r.json()
-results = data.get('query', {}).get('search', [])
-if results and brand.lower() in results[0].get('title', '').lower():
-    print(f'WIKIPEDIA PAGE EXISTS: {results[0][\"title\"]}')
-    print(f'URL: https://en.wikipedia.org/wiki/{results[0][\"title\"].replace(\" \", \"_\")}')
-else:
-    print('No direct Wikipedia page found')
-# Check Wikidata
-wd_url = f'https://www.wikidata.org/w/api.php?action=wbsearchentities&search={quote_plus(brand)}&language=en&format=json'
-r2 = requests.get(wd_url, headers={'User-Agent': 'GEO-Audit/1.0'}, timeout=15)
-wd = r2.json()
-entities = wd.get('search', [])
-if entities:
-    print(f'WIKIDATA ENTRY: {entities[0].get(\"id\", \"\")} — {entities[0].get(\"description\", \"\")}')
-"
+node {baseDir}/scripts/brand-scanner.mjs --url <url> --brand "<brand name>"
 ```
 
-**Method 2 — Direct URL check (backup verification):**
-1. WebFetch: `https://en.wikipedia.org/wiki/[Brand_Name]` — check if the page loads (not a redirect to search)
-2. WebFetch: `https://en.wikipedia.org/wiki/[Founder_Name]` for founder article
-
-**Method 3 — Search (least reliable, use only for supplemental info):**
-1. Search: `[brand name] site:wikipedia.org`
-2. Search: `[brand name] site:wikidata.org`
-
-**CRITICAL:** Web search alone is NOT reliable for determining Wikipedia presence. ALWAYS run the Python API check first. If the API says a page exists, it exists — do not override this with a search result that fails to find it.
-
-5. Note: Article existence, quality, edit history, Wikidata completeness
-
-**LinkedIn Check:**
-1. Search: `[brand name] site:linkedin.com`
-2. Check: `linkedin.com/company/[brand-name]` for company page
-3. Note: Follower count, post frequency, employee count listed, engagement levels
-
-**Other Platforms:**
-1. Search: `[brand name] site:quora.com`
-2. Search: `[brand name] site:stackoverflow.com` (if technical brand)
-3. Search: `[brand name] site:github.com` (if technical brand)
-4. Search: `[brand name] site:news.ycombinator.com` (Hacker News)
-5. Search: `"[brand name]"` broadly for news mentions (filter to last 6 months)
-6. Note: Presence/absence and quality of mentions on each platform
-
-### Step 3: Sentiment Assessment
-
-For Reddit and other discussion platforms, assess sentiment by analyzing the most recent and most prominent mentions:
-
-| Sentiment | Indicators |
-|---|---|
-| **Positive** | Recommendations ("I love [brand]," "We switched to [brand] and...", "Highly recommend"), upvoted mentions, positive comparison against competitors |
-| **Neutral** | Factual mentions ("We use [brand] for...", "[Brand] offers..."), questions about the brand, balanced comparisons |
-| **Negative** | Complaints ("Avoid [brand]", "[Brand] has terrible support"), downvoted recommendations, negative comparisons |
-| **Mixed** | Combination of positive and negative. Note the ratio and primary themes. |
-
-### Step 4: Competitive Comparison (Optional)
-
-If competitors are identified, do a quick scan of their platform presence for context. This helps calibrate the score -- a brand with "moderate" Reddit presence in an industry where competitors have zero Reddit presence is relatively strong.
-
-### Step 5: Score Calculation
-
-1. Score each platform (0-100) using the rubrics above.
-2. Apply weights to calculate the composite Brand Authority Score.
-3. Identify the strongest and weakest platforms.
-4. Generate specific, actionable recommendations for the weakest platforms.
-
----
-
-## Output Format
-
-Generate a file called `GEO-BRAND-MENTIONS.md`:
-
-```markdown
-# Brand Authority Report: [Brand Name]
-
-**Analysis Date:** [Date]
-**Brand:** [Brand Name]
-**Domain:** [URL]
-**Industry:** [Industry]
-
----
-
-## Brand Authority Score: [X]/100 ([Rating])
-
-### Platform Breakdown
-
-| Platform | Score | Weight | Weighted | Status |
-|---|---|---|---|---|
-| YouTube | [X]/100 | 25% | [X] | [Active Channel / Mentioned / Absent] |
-| Reddit | [X]/100 | 25% | [X] | [Active / Discussed / Absent] |
-| Wikipedia | [X]/100 | 20% | [X] | [Article / Mentioned / Absent] |
-| LinkedIn | [X]/100 | 15% | [X] | [Active / Basic / Absent] |
-| Other Platforms | [X]/100 | 15% | [X] | [Summary] |
-| **Total** | | | **[X]/100** | |
-
----
-
-## Platform Detail
-
-### YouTube ([X]/100)
-
-**Official Channel:** [Yes/No] | [URL if exists]
-**Subscribers:** [Count or N/A]
-**Videos:** [Count or N/A]
-**Last Upload:** [Date or N/A]
-**Third-Party Mentions:** [Estimated count]
-**Key Findings:**
-- [Finding 1]
-- [Finding 2]
-
-### Reddit ([X]/100)
-
-**Official Account:** [Yes/No] | [URL if exists]
-**Own Subreddit:** [Yes/No] | [URL and member count if exists]
-**Mention Volume:** [Estimated thread count]
-**Primary Subreddits:** [List of subreddits where brand is discussed]
-**Sentiment:** [Positive/Negative/Neutral/Mixed]
-**Key Findings:**
-- [Finding 1]
-- [Finding 2]
-
-### Wikipedia ([X]/100)
-
-**Company Article:** [Yes/No] | [URL if exists]
-**Founder Article:** [Yes/No] | [URL if exists]
-**Wikidata Entry:** [Yes/No] | [Q-number if exists]
-**Cited in Other Articles:** [Yes/No] | [Which articles]
-**Key Findings:**
-- [Finding 1]
-- [Finding 2]
-
-### LinkedIn ([X]/100)
-
-**Company Page:** [Yes/No] | [URL if exists]
-**Followers:** [Count or N/A]
-**Post Frequency:** [Weekly/Monthly/Rare/Never]
-**Key Findings:**
-- [Finding 1]
-- [Finding 2]
-
-### Other Platforms ([X]/100)
-
-| Platform | Presence | Notes |
-|---|---|---|
-| Quora | [Yes/No] | [Brief note] |
-| Stack Overflow | [Yes/No] | [Brief note] |
-| GitHub | [Yes/No] | [Brief note] |
-| Hacker News | [Yes/No] | [Brief note] |
-| News/Press | [Yes/No] | [Brief note] |
-| Podcasts | [Yes/No] | [Brief note] |
-
----
-
-## Recommendations
-
-### Immediate Actions (Week 1-2)
-
-1. **[Platform]:** [Specific action to take with expected impact]
-2. **[Platform]:** [Specific action]
-
-### Short-Term Strategy (Month 1-3)
-
-1. **[Platform]:** [Strategy with tactics]
-2. **[Platform]:** [Strategy with tactics]
-
-### Long-Term Authority Building (Month 3-12)
-
-1. **[Platform]:** [Long-term strategy]
-2. **[Platform]:** [Long-term strategy]
-
----
-
-## Competitive Context
-
-[If competitors were analyzed, show a brief comparison table]
-
-| Brand | YouTube | Reddit | Wikipedia | LinkedIn | Other | Total |
-|---|---|---|---|---|---|---|
-| [Subject Brand] | [X] | [X] | [X] | [X] | [X] | **[X]** |
-| [Competitor 1] | [X] | [X] | [X] | [X] | [X] | **[X]** |
-| [Competitor 2] | [X] | [X] | [X] | [X] | [X] | **[X]** |
-
-## Key Takeaway
-
-[1-2 sentence summary of the brand's AI visibility standing and the single most impactful action to take]
+Outputs JSON to stdout:
+```json
+{
+  "brand": "Acme Corp",
+  "platforms": {
+    "youtube": { "status": "confirmed|inconclusive|not_found", "url": "...", "notes": "..." },
+    "reddit": { "status": "confirmed|inconclusive|not_found", "url": "...", "notes": "..." },
+    "wikipedia": { "status": "confirmed|inconclusive|not_found", "url": "...", "notes": "..." },
+    "linkedin": { "status": "confirmed|inconclusive|not_found", "url": "...", "notes": "..." }
+  }
+}
 ```
 
+Status values:
+- `confirmed` — HTTP check or API returned positive match
+- `inconclusive` — search indicates presence but could not verify directly
+- `not_found` — no presence detected
+
 ---
 
-## Reference Data
+## Platform Weights
 
-### Correlation Strengths (Ahrefs Dec 2025, 75K Brands)
-
-| Signal | Correlation with AI Citation | Traditional SEO Value |
+| Platform | Weight | Correlation with AI citation |
 |---|---|---|
-| YouTube mentions | ~0.737 | Low (not a ranking factor) |
-| Reddit mentions | High (exact coefficient not published) | Low |
-| Wikipedia presence | High | Moderate (trust signal) |
-| LinkedIn presence | Moderate | Low |
-| Domain Rating | ~0.266 | Very High |
-| Backlink count | ~0.266 | Very High |
-| Organic traffic | Moderate | Very High |
+| YouTube | 25% | ~0.737 (Ahrefs Dec 2025) — strongest signal |
+| Reddit | 25% | High — heavily indexed in AI training data |
+| Wikipedia | 20% | High — primary entity recognition source |
+| LinkedIn | 15% | Moderate — professional authority |
+| Other (Quora, GitHub, news, HN) | 15% | Supplementary |
 
-**Key insight:** The signals that matter most for AI visibility (YouTube, Reddit) are almost irrelevant in traditional SEO, and the signals that matter most for traditional SEO (backlinks, DR) are weak predictors of AI visibility. This requires a fundamentally different optimization strategy.
+---
 
-### Platform-Specific Tips for Building Presence
+## Scoring (0–100)
 
-**YouTube Quick Wins:**
-- Create a channel and upload 3-5 explainer videos about your core topics.
-- Ensure your brand name appears in video titles, descriptions, and spoken content.
-- Pursue guest appearances on relevant industry YouTube channels.
-- Create comparison or "alternatives" videos (these get cited by AI for comparison queries).
+Brand_Authority_Score = (YouTube × 0.25) + (Reddit × 0.25) + (Wikipedia × 0.20)
+                       + (LinkedIn × 0.15) + (Other × 0.15)
 
-**Reddit Quick Wins:**
-- Identify 3-5 subreddits where your target audience is active.
-- Participate authentically (do not shill -- Reddit communities detect and punish this).
-- Do an AMA if appropriate for your brand.
-- Monitor and respond to mentions of your brand.
-- Create genuinely helpful posts that naturally mention your brand's expertise.
+### Per-Platform Score Guide
 
-**Wikipedia Strategy:**
-- Hire a Wikipedia-knowledgeable consultant -- do NOT edit your own article (conflict of interest).
-- Build notability through press coverage, academic citations, and industry recognition first.
-- Ensure your Wikidata entry is complete even if you do not have a Wikipedia article.
-- Contribute to industry-relevant articles where your brand can be naturally cited as a source.
+**YouTube (0–100):**
+- 90–100: Active channel 10K+ subscribers, 20+ third-party mentions
+- 50–69: Channel exists, 5–9 third-party mentions
+- 0–9: No YouTube presence
 
-**LinkedIn Quick Wins:**
-- Optimize your company page with complete information and regular posting.
-- Encourage leadership to post thought leadership content weekly.
-- Publish LinkedIn articles on topics where your brand has unique expertise.
-- Engage with industry discussions to increase brand visibility in professional contexts.
+**Reddit (0–100):**
+- 90–100: Frequently recommended in subreddits, positive sentiment, active official presence
+- 50–69: Mentioned in several threads, brand recognised by community
+- 0–9: No Reddit presence
+
+**Wikipedia (0–100):**
+- 90–100: Detailed article (B-class+), Wikidata entry with complete properties
+- 50–69: Article exists (stub), basic Wikidata entry
+- 0–9: No Wikipedia or Wikidata presence
+
+**LinkedIn (0–100):**
+- 90–100: 10K+ followers, leadership posts thought leadership, frequent third-party mentions
+- 50–69: 1K+ followers, irregular posting
+- 0–9: No company page
+
+---
+
+## Worker Return Format
+
+```json
+{
+  "score": 38,
+  "critical_3": [
+    "No Wikipedia article — AI systems may not recognise brand as a distinct entity",
+    "No Wikidata entry — missing from AI knowledge graphs",
+    "YouTube channel not found — strongest AI citation signal absent"
+  ],
+  "quick_wins_3": [
+    "Create Wikidata entity with official website, founding date, and LinkedIn URL",
+    "Launch YouTube channel with 3 explainer videos on core topics",
+    "Ensure brand is mentioned authentically in 2-3 relevant subreddits"
+  ]
+}
+```

--- a/skills/geo-citability/SKILL.md
+++ b/skills/geo-citability/SKILL.md
@@ -1,319 +1,139 @@
 ---
 name: geo-citability
-description: AI citability scoring and optimization. Analyzes web page content to determine how likely AI systems (ChatGPT, Claude, Perplexity, Gemini) are to cite or quote passages from the page. Provides a citability score (0-100) with specific rewrite suggestions.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - WebFetch
-  - Write
+description: >
+  Passage-level AI citation readiness. Scores content blocks for how likely AI systems
+  (ChatGPT, Claude, Perplexity, Gemini) are to extract and cite them verbatim. Produces
+  a citability score (0-100) with specific rewrite suggestions per block. Invoked
+  directly via /geo citability or as a parallel worker in /geo audit.
 ---
 
-# AI Citability Scoring Skill
+# GEO Citability Scorer
 
-## Core Insight
+## Purpose
 
-AI language models cite passages that meet specific structural criteria. Research from Princeton, Georgia Tech, and IIT Delhi (2024) found that GEO-optimized content achieves 30-115% higher visibility in AI-generated responses. The key finding: AI systems preferentially extract and cite passages that are **134-167 words long**, **self-contained** (understandable without surrounding context), **fact-rich** (containing specific statistics, dates, or named entities), and **directly answer a question** in the first 1-2 sentences.
+Score individual content passages for AI citation readiness. A passage is citable when
+it is self-contained, answer-first, fact-dense, and within the 134–167 word optimal
+extraction range (Bortolato 2025 analysis of AI Overview passages).
 
-This is fundamentally different from traditional SEO copywriting, which optimizes for keyword density and user engagement metrics. GEO citability optimizes for **extractability** -- the ease with which an AI system can pull a passage from your content and present it as a direct answer.
+**This worker's domain:** passage-level extractability only.
+Content quality (E-E-A-T) is handled by `geo-content`.
 
 ---
 
-## Citability Scoring Rubric (0-100)
+## Script
 
-### Category 1: Answer Block Quality (30% of total score)
+```bash
+node {baseDir}/scripts/citability-scorer.mjs --url <url>
+```
 
-This measures whether content contains clear, quotable answer passages that AI systems can extract verbatim.
+Outputs JSON to stdout:
+```json
+{
+  "url": "https://...",
+  "overall_score": 72,
+  "blocks": [
+    {
+      "heading": "What is a CDN?",
+      "word_count": 58,
+      "score": 88,
+      "weaknesses": []
+    }
+  ]
+}
+```
 
-**Scoring Criteria:**
+---
 
-| Score | Criteria |
-|---|---|
-| **90-100** | Every major section opens with a 1-2 sentence direct answer. Uses "X is..." or "X refers to..." patterns. First 40-60 words of each section can stand alone as a complete answer. |
-| **70-89** | Most sections have clear answer openings. Some definition patterns present. Answers are identifiable but may need minor context. |
-| **50-69** | Some sections have answer-like openings but many bury the answer in the middle or end of paragraphs. Few explicit definition patterns. |
-| **30-49** | Answers are generally buried in long paragraphs. No consistent definition patterns. Content is narrative-driven rather than answer-driven. |
-| **0-29** | No identifiable answer blocks. Content is entirely narrative, conversational, or fragmented. AI would struggle to extract any quotable passage. |
+## Scoring Rubric (0–100)
 
-**What to look for:**
+| Category | Weight | What It Measures |
+|---|---|---|
+| Answer Block Quality | 30% | Direct, answer-first structure |
+| Passage Self-Containment | 25% | Can be extracted without surrounding context |
+| Structural Readability | 20% | Heading hierarchy, paragraph length, lists, tables |
+| Statistical Density | 15% | Specific data points and named sources |
+| Uniqueness | 10% | Original insight not available elsewhere |
 
-- **Definition patterns:** "X is [definition]." / "X refers to [explanation]." / "X means [meaning]."
-- **Answer-first structure:** The answer appears in the first sentence, followed by supporting detail.
-- **Quantified answers:** "The average cost of X is $Y" rather than "Many factors affect the cost of X."
-- **Comparison answers:** "X differs from Y in three ways: [list]" rather than "X and Y are often confused."
+### Answer Block Quality (30 pts)
+
+Score 90–100: Every section opens with a direct 1–2 sentence answer. Uses "X is..." or
+"X refers to..." patterns. First 40–60 words stand alone as a complete answer.
+
+Score 50–69: Some answer-like openings, many bury the answer mid-paragraph.
+
+Score 0–29: No identifiable answer blocks. Entirely narrative or conversational.
 
 **High-citability example:**
-```
-Content delivery networks (CDNs) are distributed server systems that cache and serve
-web content from locations geographically close to end users. A CDN reduces latency
-by 50-70% on average by serving assets from edge servers rather than a single origin
-server. The three largest CDN providers as of 2025 are Cloudflare (serving approximately
-20% of all websites), Amazon CloudFront, and Akamai Technologies.
-```
-Word count: 58. Self-contained: Yes. Facts: 3 specific data points. Definition pattern: Yes.
+> Content delivery networks (CDNs) are distributed server systems that cache and serve
+> web content from locations geographically close to end users. A CDN reduces latency
+> by 50–70% on average. The three largest CDN providers as of 2025 are Cloudflare
+> (~20% of all websites), Amazon CloudFront, and Akamai Technologies.
 
 **Low-citability example:**
-```
-If you've ever wondered why some websites load faster than others, the answer might
-surprise you. There's this amazing technology that has been around for a while now.
-It's changed the way we think about web performance. Let me explain how it works and
-why you should care about it for your business.
-```
-Word count: 52. Self-contained: No (no topic identified). Facts: 0. Definition pattern: No.
+> If you've ever wondered why some websites load faster than others, the answer might
+> surprise you. There's this amazing technology that has been around for a while now.
 
----
+### Passage Self-Containment (25 pts)
 
-### Category 2: Passage Self-Containment (25% of total score)
-
-This measures whether individual passages can be extracted and understood without needing the surrounding content.
-
-**Scoring Criteria:**
-
-| Score | Criteria |
-|---|---|
-| **90-100** | 80%+ of content blocks are fully self-contained. Each passage names its subject explicitly. No reliance on pronouns referencing earlier content. Contains specific facts within the passage. |
-| **70-89** | 60-79% of content blocks are self-contained. Most passages name their subject. Occasional pronoun references that require context. |
-| **50-69** | 40-59% of content blocks are self-contained. Mixed use of explicit subjects and pronouns. Some passages require reading prior sections. |
-| **30-49** | 20-39% of content blocks are self-contained. Heavy reliance on pronouns and contextual references. Most passages need surrounding text. |
-| **0-29** | Under 20% self-contained. Content reads as a continuous narrative where extracting any paragraph loses meaning. |
-
-**Self-containment checklist for each passage:**
-
-1. Does the passage explicitly name the subject (not "it," "this," "they")?
+Checklist per block:
+1. Does it explicitly name the subject (not "it", "this", "they")?
 2. Can someone understand the main point reading ONLY this passage?
-3. Does the passage contain at least one specific fact, statistic, or named entity?
-4. Is the passage between 50-200 words (the optimal extraction length)?
-5. Does the passage avoid starting with conjunctions ("But," "However," "And") that imply prior context?
+3. Does it contain at least one specific fact, statistic, or named entity?
+4. Is it between 50–200 words?
+5. Does it avoid starting with conjunctions ("But", "However") that imply prior context?
+
+Score 90–100: 80%+ of blocks pass all 5 checks.
+Score 0–29: Under 20% self-contained.
+
+### Structural Readability (20 pts)
+
+- Clean H1 > H2 > H3 hierarchy, no skipped levels
+- Question-based headings for informational content
+- Paragraphs: 2–4 sentences
+- Tables for any comparison of 3+ items
+- Ordered lists for sequential processes, unordered for features/options
+
+### Statistical Density (15 pts)
+
+Score 90–100: 5+ specific statistics per 500 words, all claims backed by named sources
+or dates, exact numbers not vague quantifiers.
+
+What counts: percentages, dollar amounts, timeframes, named studies, specific counts,
+before/after comparisons.
+
+What does NOT count: "Many companies use...", "A significant percentage...",
+"Studies show..." (no named source).
+
+### Uniqueness (10 pts)
+
+Score 90–100: Contains first-party research, proprietary data, original surveys, or
+analysis not found elsewhere.
 
 ---
 
-### Category 3: Structural Readability (20% of total score)
+## Worker Return Format
 
-This measures the structural formatting that helps AI systems parse and segment content.
-
-**Scoring Criteria:**
-
-| Score | Criteria |
-|---|---|
-| **90-100** | Clean H1 > H2 > H3 hierarchy. Question-based headings for informational content. Short paragraphs (2-4 sentences). Tables for comparisons. Ordered lists for processes. Unordered lists for features/options. |
-| **70-89** | Good heading hierarchy with minor skips. Some question-based headings. Mostly short paragraphs. Some use of tables and lists. |
-| **50-69** | Heading hierarchy present but inconsistent. Few question-based headings. Mix of short and long paragraphs. Limited tables/lists. |
-| **30-49** | Minimal heading structure. No question-based headings. Long paragraphs dominate. Rare use of tables/lists. |
-| **0-29** | No heading structure or severely broken hierarchy. Wall-of-text paragraphs. No tables or lists. |
-
-**Structural best practices for AI citability:**
-
-- **Heading hierarchy:** H1 (page title) > H2 (major sections) > H3 (subsections). Never skip levels.
-- **Question-based headings:** "What is [topic]?" and "How does [topic] work?" are directly matchable to AI queries.
-- **Paragraph length:** 2-4 sentences per paragraph. AI systems parse short paragraphs more reliably.
-- **Tables:** Use for any comparison of 3+ items. AI systems extract table data with high accuracy.
-- **Lists:** Use ordered lists for sequential processes, unordered lists for non-sequential items.
-- **Bold key terms:** Bold the first use of important terms. This aids AI entity recognition.
-
----
-
-### Category 4: Statistical Density (15% of total score)
-
-This measures the presence of specific, verifiable data points that AI systems prioritize when selecting citation sources.
-
-**Scoring Criteria:**
-
-| Score | Criteria |
-|---|---|
-| **90-100** | 5+ specific statistics per 500 words. All claims backed by named sources or dates. Uses exact numbers (not "many" or "several"). Includes percentages, dollar amounts, timeframes, and named studies. |
-| **70-89** | 3-4 statistics per 500 words. Most claims have sources. Mostly specific numbers with occasional vague quantifiers. |
-| **50-69** | 1-2 statistics per 500 words. Some claims sourced. Mix of specific and vague numbers. |
-| **30-49** | Less than 1 statistic per 500 words. Few sourced claims. Predominantly vague quantifiers. |
-| **0-29** | No statistics. No sourced claims. All quantifiers are vague ("many," "most," "a lot"). |
-
-**What counts as a statistic:**
-- Specific percentages: "73% of marketers report..."
-- Dollar amounts: "The average cost is $4,500 per month"
-- Timeframes: "Implementation takes 6-8 weeks on average"
-- Named studies: "According to the 2025 HubSpot State of Marketing Report..."
-- Specific counts: "The platform integrates with 340+ tools"
-- Comparison data: "40% faster than the industry average"
-
-**What does NOT count:**
-- "Many companies use..." (vague)
-- "A significant percentage..." (vague)
-- "Studies show that..." (no named source)
-- "Experts agree..." (no named experts)
-
----
-
-### Category 5: Uniqueness & Original Data (10% of total score)
-
-This measures whether the content provides information that AI systems cannot find elsewhere, making it a necessary citation source.
-
-**Scoring Criteria:**
-
-| Score | Criteria |
-|---|---|
-| **90-100** | Contains first-party research, proprietary data, original surveys, or unique datasets. Presents analysis or insights not found on any other page. Clear methodological descriptions. |
-| **70-89** | Contains some original insights or unique analysis of existing data. Offers a distinct perspective with original examples. |
-| **50-69** | Mostly synthesizes existing information but adds some unique commentary or examples. |
-| **30-49** | Largely derivative content that restates common knowledge with minimal original contribution. |
-| **0-29** | Entirely derivative. All information is available (often verbatim) on higher-authority sources. |
-
-**Signals of unique content:**
-- "Our analysis of [X] data found..."
-- "We surveyed [N] [professionals] and found..."
-- "Based on our experience with [N] clients..."
-- Custom charts, graphs, or data visualizations
-- Case studies with specific named outcomes
-- Original frameworks, methodologies, or taxonomies
-
----
-
-## Analysis Procedure
-
-### Step 1: Fetch and Parse Page Content
-
-1. Use WebFetch to retrieve the target URL.
-2. Extract the main content area (exclude navigation, footer, sidebar, ads).
-3. Preserve heading structure (H1-H6 tags).
-4. Preserve paragraph boundaries, lists, and tables.
-5. Calculate total word count of main content.
-
-### Step 2: Segment Content into Blocks
-
-1. Split content at each heading (H2 or H3) to create content blocks.
-2. For each block, record:
-   - The heading text
-   - The full text content under that heading
-   - Word count of the block
-   - Number of paragraphs
-   - Number of lists and tables
-   - Number of statistics/data points
-   - Whether the block contains a definition pattern
-   - Whether the first 60 words form a standalone answer
-
-### Step 3: Score Each Block
-
-For each content block, calculate:
-- Answer Block Quality sub-score (0-100)
-- Self-Containment sub-score (0-100)
-- Structural Readability sub-score (0-100)
-- Statistical Density sub-score (0-100)
-- Uniqueness sub-score (0-100)
-
-**Block Citability Score** = (Answer * 0.30) + (SelfContain * 0.25) + (Structure * 0.20) + (Stats * 0.15) + (Unique * 0.10)
-
-### Step 4: Calculate Page-Level Score
-
-1. Calculate the average of all block scores for the page-level citability score.
-2. Identify the top 3 highest-scoring blocks (highlight as strengths).
-3. Identify the bottom 3 lowest-scoring blocks (flag for rewriting).
-4. Calculate the percentage of blocks scoring above 70 (the "citability coverage" metric).
-
-### Step 5: Generate Rewrite Suggestions
-
-For each block scoring below 60, generate a specific rewrite suggestion:
-1. Identify the primary weakness (buried answer, lack of facts, poor structure, etc.).
-2. Propose a rewritten opening sentence using a definition or answer-first pattern.
-3. Suggest specific statistics or facts that could be added.
-4. Recommend structural improvements (add list, add table, split paragraph).
-
----
-
-## Output Format
-
-Generate a file called `GEO-CITABILITY-SCORE.md`:
-
-```markdown
-# AI Citability Analysis: [Page Title]
-
-**URL:** [URL]
-**Analysis Date:** [Date]
-**Overall Citability Score: [X]/100**
-**Citability Coverage:** [X]% of content blocks score above 70
-
----
-
-## Score Summary
-
-| Category | Score | Weight | Weighted |
-|---|---|---|---|
-| Answer Block Quality | [X]/100 | 30% | [X] |
-| Passage Self-Containment | [X]/100 | 25% | [X] |
-| Structural Readability | [X]/100 | 20% | [X] |
-| Statistical Density | [X]/100 | 15% | [X] |
-| Uniqueness & Original Data | [X]/100 | 10% | [X] |
-| **Overall** | | | **[X]/100** |
-
----
-
-## Strongest Content Blocks
-
-### 1. "[Heading]" -- Score: [X]/100
-> [First 2 sentences of the block]
-
-**Why it works:** [Explanation]
-
-### 2. "[Heading]" -- Score: [X]/100
-> [First 2 sentences of the block]
-
-**Why it works:** [Explanation]
-
----
-
-## Weakest Content Blocks (Rewrite Priority)
-
-### 1. "[Heading]" -- Score: [X]/100
-
-**Current opening:**
-> [First 2 sentences as they exist]
-
-**Problem:** [Specific issue -- buried answer, no facts, etc.]
-
-**Suggested rewrite:**
-> [Rewritten opening 2-3 sentences with answer-first pattern and facts]
-
-**Additional improvements:**
-- [Add table comparing X, Y, Z]
-- [Include statistic about ...]
-- [Split long paragraph into 2-3 shorter ones]
-
----
-
-## Quick Win Reformatting Recommendations
-
-1. **[Specific recommendation]** -- Expected citability lift: +[X] points
-2. **[Specific recommendation]** -- Expected citability lift: +[X] points
-3. **[Specific recommendation]** -- Expected citability lift: +[X] points
-4. **[Specific recommendation]** -- Expected citability lift: +[X] points
-5. **[Specific recommendation]** -- Expected citability lift: +[X] points
-
----
-
-## Per-Section Scores
-
-| Section Heading | Words | Answer Quality | Self-Contained | Structure | Stats | Unique | Overall |
-|---|---|---|---|---|---|---|---|
-| [H2 heading] | [N] | [X] | [X] | [X] | [X] | [X] | [X] |
+```json
+{
+  "score": 72,
+  "critical_3": [
+    "Homepage hero section buries answer — no direct first sentence in 6 of 8 blocks",
+    "Blog posts average 23 words per paragraph (too short; lacks supporting evidence)",
+    "Zero statistics with named sources across sampled pages"
+  ],
+  "quick_wins_3": [
+    "Rewrite H2 openings to lead with definition pattern: 'X is...'",
+    "Add 3 specific data points with citations to /services page",
+    "Convert the 4-paragraph comparison section into a table"
+  ]
+}
 ```
 
 ---
 
-## Reference Data
+## Research Reference
 
-### Optimal Passage Characteristics (from GEO Research)
-
-- **Optimal length for AI citation:** 134-167 words (Bortolato 2025 analysis of AI Overview passages)
-- **Definition patterns increase citation rate by:** 2.1x (Georgia Tech 2024)
-- **Adding statistics to passages increases citation by:** 40% (Princeton GEO study 2024)
-- **Adding quotations from authorities increases citation by:** 115% in certain categories (IIT Delhi 2024)
-- **Fluency optimization increases visibility by:** 30% on average across all query types
-- **Content with source citations is cited:** 20-25% more often by Perplexity and ChatGPT search
-
-### AI System Citation Preferences
-
-| AI System | Citation Preference |
-|---|---|
-| **ChatGPT (Search)** | Prefers passages with explicit definitions, named sources, and recent dates. Tends to cite 2-4 sources per response. |
-| **Perplexity** | Heavily favors fact-dense passages with statistics. Cites 4-8 sources per response. Values recency highly. |
-| **Claude** | Prefers well-structured, comprehensive passages. Values nuance and accuracy over brevity. |
-| **Gemini (AI Overviews)** | Prefers concise answer blocks (40-60 words). Values content already ranking in top 10 organic results. |
-| **Copilot (Bing)** | Similar to Gemini. Prefers passages from high-authority domains with clear factual claims. |
+- Optimal extraction length: 134–167 words (Bortolato 2025)
+- Definition patterns increase citation rate by 2.1x (Georgia Tech 2024)
+- Adding statistics to passages increases citation by 40% (Princeton GEO study 2024)
+- Fluency optimisation increases visibility by 30% on average (IIT Delhi 2024)

--- a/skills/geo-content/SKILL.md
+++ b/skills/geo-content/SKILL.md
@@ -1,345 +1,189 @@
 ---
 name: geo-content
-description: Content quality and E-E-A-T assessment for AI citability — evaluate experience, expertise, authoritativeness, trustworthiness, and content structure
-version: 1.0.0
-author: geo-seo-claude
-tags: [geo, content-quality, eeat, citability, ai-content, topical-authority]
-allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+description: >
+  E-E-A-T content quality assessment. Evaluates Experience, Expertise, Authoritativeness,
+  and Trustworthiness signals at page level. Also assesses content freshness, topical
+  authority, and AI content quality. Invoked directly via /geo content or as a parallel
+  worker in /geo audit.
 ---
 
-# GEO Content Quality & E-E-A-T Assessment
+# GEO Content Quality & E-E-A-T Assessor
 
 ## Purpose
 
-AI search platforms do not just find content — they evaluate whether content deserves to be cited. The primary framework for this evaluation is **E-E-A-T** (Experience, Expertise, Authoritativeness, Trustworthiness), which per Google's December 2025 Quality Rater Guidelines update now applies to **ALL competitive queries**, not just YMYL (Your Money Your Life) topics. Content that scores high on E-E-A-T is dramatically more likely to be cited by AI platforms.
+AI search platforms evaluate whether content deserves to be cited. E-E-A-T (Experience,
+Expertise, Authoritativeness, Trustworthiness) per Google's Dec 2025 Quality Rater
+Guidelines update now applies to ALL competitive queries.
 
-This skill evaluates content through two lenses:
-1. **E-E-A-T signals** — does the content demonstrate real expertise and trust?
-2. **AI citability** — is the content structured so AI platforms can extract and cite specific claims?
-
-## How to Use This Skill
-
-1. Fetch the target page(s) — homepage, key blog posts, service/product pages
-2. Evaluate E-E-A-T across the 4 dimensions (25% each)
-3. Assess content quality metrics (structure, readability, depth)
-4. Check for AI content quality signals
-5. Evaluate topical authority across the site
-6. Score and generate GEO-CONTENT-ANALYSIS.md
+**This worker's domain:** page-level E-E-A-T, author authority, content freshness,
+topical depth, and content structure quality.
+Passage-level citability scoring (extractability) is handled by `geo-citability`.
 
 ---
 
-## E-E-A-T Framework (100 points total)
+## E-E-A-T Scoring (0–100)
 
-### Experience — 25 points
-First-hand knowledge and direct involvement with the topic. AI platforms increasingly distinguish between content that reports on a topic and content from someone who has DONE it.
+| Dimension | Weight |
+|---|---|
+| Experience | 25% |
+| Expertise | 25% |
+| Authoritativeness | 25% |
+| Trustworthiness | 25% |
 
-**Signals to evaluate:**
+Topical Authority Modifier: +10 (dominant) to −5 (thin). Final score capped at 100.
 
-| Signal | Points | How to Score |
-|---|---|---|
-| First-person accounts ("I tested...", "We implemented...") | 5 | 5 if present and specific, 3 if generic, 0 if absent |
-| Original research or data not available elsewhere | 5 | 5 if original data, 3 if references original work, 0 if none |
-| Case studies with specific results | 4 | 4 if detailed with numbers, 2 if general, 0 if none |
-| Screenshots, photos, or evidence of direct use | 3 | 3 if authentic evidence, 1 if stock/generic, 0 if none |
-| Specific examples from personal experience | 4 | 4 if specific and unique, 2 if somewhat specific, 0 if generic |
-| Demonstrations of process (not just outcome) | 4 | 4 if step-by-step from experience, 2 if partial, 0 if none |
+### Experience (25 pts)
 
-**What to flag as weak Experience:**
-- Content that only summarizes what other sources say without adding new perspective
-- Generic advice that could apply to any situation ("It depends on your needs")
-- No mention of actual usage, testing, or direct involvement
-- Hedging language that suggests lack of direct knowledge ("reportedly", "supposedly", "some say")
+Signals of first-hand knowledge:
 
-### Expertise — 25 points
-Demonstrated knowledge depth and professional competence in the subject matter.
+| Signal | Max pts |
+|---|---|
+| First-person accounts ("I tested...", "We implemented...") | 5 |
+| Original research or data not available elsewhere | 5 |
+| Case studies with specific results and numbers | 4 |
+| Screenshots, photos, or evidence of direct use | 3 |
+| Specific examples from personal experience | 4 |
+| Demonstrations of process (not just outcome) | 4 |
 
-**Signals to evaluate:**
+**Weak Experience flags:** only summarises other sources, generic advice applicable to
+any situation, no mention of direct usage, hedging language ("reportedly", "some say").
 
-| Signal | Points | How to Score |
-|---|---|---|
-| Author credentials visible (bio, degrees, certifications) | 5 | 5 if full credentials, 3 if basic bio, 0 if no author |
-| Technical depth appropriate to topic | 5 | 5 if thorough technical treatment, 3 if adequate, 0 if superficial |
-| Methodology explanation (how conclusions were reached) | 4 | 4 if clear methodology, 2 if some explanation, 0 if none |
-| Data-backed claims (statistics, research citations) | 4 | 4 if well-sourced, 2 if some data, 0 if unsupported claims |
-| Industry-specific terminology used correctly | 3 | 3 if accurate specialized language, 1 if basic, 0 if errors |
-| Author page with detailed professional background | 4 | 4 if dedicated author page, 2 if brief bio, 0 if none |
+### Expertise (25 pts)
 
-**What to flag as weak Expertise:**
-- Claims without supporting evidence or sources
-- Surface-level coverage of complex topics
-- Misuse of technical terminology
-- No visible author or author without relevant credentials
-- Content that is broad and generic rather than deep and specific
+| Signal | Max pts |
+|---|---|
+| Author credentials visible (bio, degrees, certs) | 5 |
+| Technical depth appropriate to topic | 5 |
+| Methodology explanation (how conclusions were reached) | 4 |
+| Data-backed claims with named sources | 4 |
+| Industry-specific terminology used correctly | 3 |
+| Author page with detailed professional background | 4 |
 
-### Authoritativeness — 25 points
-Recognition by others as a credible source on the topic.
+**Weak Expertise flags:** claims without evidence, surface-level coverage, no visible
+author, misuse of technical terms.
 
-**Signals to evaluate:**
+### Authoritativeness (25 pts)
 
-| Signal | Points | How to Score |
-|---|---|---|
-| Inbound citations from authoritative sources | 5 | 5 if cited by major sources, 3 if some citations, 0 if none |
-| Author quoted or cited in press/media | 4 | 4 if media mentions, 2 if industry mentions, 0 if none |
-| Industry awards or recognition mentioned | 3 | 3 if relevant awards, 1 if tangential, 0 if none |
-| Speaker credentials (conferences, events) | 3 | 3 if listed, 0 if none |
-| Published in peer-reviewed or respected outlets | 4 | 4 if tier-1 publications, 2 if industry outlets, 0 if none |
-| Comprehensive topic coverage (topical authority) | 3 | 3 if site covers topic thoroughly, 1 if some coverage, 0 if isolated |
-| Brand mentioned on Wikipedia or authoritative references | 3 | 3 if Wikipedia, 2 if other encyclopedic refs, 0 if none |
+| Signal | Max pts |
+|---|---|
+| Inbound citations from authoritative sources | 5 |
+| Author quoted or cited in press/media | 4 |
+| Industry awards or recognition | 3 |
+| Speaker credentials (conferences, events) | 3 |
+| Published in peer-reviewed or respected outlets | 4 |
+| Comprehensive topic coverage (topical authority) | 3 |
+| Brand mentioned on Wikipedia or authoritative refs | 3 |
 
-**What to flag as weak Authoritativeness:**
-- Single-topic site with no depth of coverage
-- No external validation of expertise claims
-- No backlinks from authoritative sources
-- Claims of authority without evidence (self-proclaimed "expert")
+### Trustworthiness (25 pts)
 
-### Trustworthiness — 25 points
-Signals that the content and its publisher are reliable and transparent.
-
-**Signals to evaluate:**
-
-| Signal | Points | How to Score |
-|---|---|---|
-| Contact information visible (address, phone, email) | 4 | 4 if full contact info, 2 if email only, 0 if none |
-| Privacy policy present and linked | 2 | 2 if present, 0 if absent |
-| Terms of service present | 1 | 1 if present, 0 if absent |
-| HTTPS with valid certificate | 2 | 2 if valid HTTPS, 0 if not |
-| Editorial standards or corrections policy | 3 | 3 if documented, 1 if implicit, 0 if none |
-| Transparent about business model and conflicts | 3 | 3 if clear disclosures, 1 if some, 0 if none |
-| Reviews and testimonials from real customers | 3 | 3 if verified reviews, 1 if testimonials, 0 if none |
-| Accurate claims (no misinformation detected) | 4 | 4 if all claims accurate, 2 if mostly accurate, 0 if errors found |
-| Clear affiliate/sponsorship disclosures | 3 | 3 if properly disclosed, 0 if undisclosed or absent |
-
-**What to flag as weak Trustworthiness:**
-- No contact information or physical address
-- Missing privacy policy or terms
-- Undisclosed affiliate links or sponsored content
-- Claims that are verifiably false or misleading
-- No way to contact the publisher for corrections
+| Signal | Max pts |
+|---|---|
+| Contact information visible (address, phone, email) | 4 |
+| Privacy policy present and linked | 2 |
+| Terms of service present | 1 |
+| HTTPS with valid cert | 2 |
+| Editorial standards or corrections policy | 3 |
+| Transparent about business model and conflicts | 3 |
+| Verified reviews/testimonials | 3 |
+| Accurate claims (no detectable misinformation) | 4 |
+| Clear affiliate/sponsorship disclosures | 3 |
 
 ---
 
-## Content Quality Metrics
+## Content Quality Checks
 
-### Word Count Benchmarks
-These are **floors, not targets**. More words does not mean better content. The benchmark is the minimum length to adequately cover a topic for AI citability.
+### Word Count Benchmarks (floors, not targets)
 
-| Page Type | Minimum Words | Ideal Range | Notes |
-|---|---|---|---|
-| Homepage | 500 | 500-1,500 | Clear value proposition, not a wall of text |
-| Blog post | 1,500 | 1,500-3,000 | Thorough but focused |
-| Pillar content / Ultimate guide | 2,000 | 2,500-5,000 | Comprehensive topic coverage |
-| Product page | 300 | 500-1,500 | Descriptions, specs, use cases |
-| Service page | 500 | 800-2,000 | What, how, why, for whom |
-| About page | 300 | 500-1,000 | Company/person story and credentials |
-| FAQ page | 500 | 1,000-2,500 | Thorough answers, not one-liners |
-
-### Readability Assessment
-- **Target Flesch Reading Ease**: 60-70 (8th-9th grade level)
-- This is NOT a direct ranking factor but affects citability — AI platforms prefer content that is clear and unambiguous
-- Overly academic writing (score < 30) reduces citability for general queries
-- Overly simple writing (score > 80) may lack the depth needed for expertise signals
-
-**How to estimate without a tool:**
-- Average sentence length: 15-20 words is ideal
-- Average paragraph length: 2-4 sentences
-- Presence of jargon: should be defined when first used
-- Passive voice: < 15% of sentences
+| Page Type | Minimum | Ideal |
+|---|---|---|
+| Homepage | 500 | 500–1,500 |
+| Blog post | 1,500 | 1,500–3,000 |
+| Pillar / ultimate guide | 2,000 | 2,500–5,000 |
+| Service page | 500 | 800–2,000 |
+| About page | 300 | 500–1,000 |
 
 ### Paragraph Structure for AI Parsing
-AI platforms extract content at the paragraph level. Each paragraph should be a self-contained unit of meaning.
 
-**Optimal paragraph structure:**
-- **2-4 sentences** per paragraph (1-sentence paragraphs are weak; 5+ sentences are hard to extract)
-- **One idea per paragraph** — do not mix topics within a paragraph
-- **Lead with the key claim** — first sentence should contain the main point
-- **Support with evidence** — remaining sentences provide data, examples, or context
-- **Quotable standalone** — each paragraph should make sense if extracted in isolation
+- 2–4 sentences per paragraph
+- One idea per paragraph
+- Lead with key claim in first sentence
+- Each paragraph quotable in isolation
 
 ### Heading Structure
-- **One H1 per page** — the primary topic/title
-- **H2 for major sections** — should represent distinct subtopics
-- **H3 for subsections** — nested under relevant H2
-- **No skipped levels** — do not go from H1 to H3 without an H2
-- **Descriptive headings** — "How to Optimize for AI Search" not "Section 2"
-- **Question-based headings** where appropriate — these map directly to AI queries
 
-### Internal Linking
-- Every content page should link to 3-5 related pages on the same site
-- Links should use descriptive anchor text (not "click here")
-- Create a topic cluster structure: pillar page linked to/from all related subtopic pages
-- Orphan pages (no internal links pointing to them) are rarely cited by AI
+- One H1 per page
+- H2 for major sections, H3 for subsections
+- No skipped levels
+- Question-based headings where appropriate ("How does X work?")
 
----
+### Content Freshness
 
-## AI Content Assessment
-
-### AI-Generated Content Policy
-AI-generated content is **acceptable** per Google's guidance (March 2024 clarification) as long as it demonstrates genuine E-E-A-T signals and has human oversight. The concern is not HOW content is created but WHETHER it provides value.
-
-### Signs of Low-Quality AI Content (flag these)
-
-| Signal | Description |
+| Currency | Status |
 |---|---|
-| Generic phrasing | "In today's fast-paced world...", "It's important to note that...", "At the end of the day..." |
-| No original insight | Content that only rephrases widely available information |
-| Lack of first-hand experience | No personal anecdotes, case studies, or specific examples |
-| Perfect but empty structure | Well-formatted headings with shallow content beneath them |
-| No specific examples | Uses abstract explanations without concrete instances |
-| Repetitive conclusions | Each section ends with a variation of the same point |
-| Hedging overload | "Generally speaking", "In most cases", "It depends on various factors" without specifying which factors |
-| Missing human voice | No opinions, preferences, or professional judgment expressed |
-| Filler content | Paragraphs that could be deleted without losing information |
-| No data or sources | Claims presented as facts without attribution or evidence |
+| Updated within 3 months | Excellent |
+| Updated within 6 months | Good |
+| Updated within 12 months | Acceptable |
+| 12–24 months ago | Warning |
+| No date or 24+ months | Critical |
 
-### High-Quality Content Signals (regardless of production method)
+---
 
-| Signal | Description |
+## AI-Generated Content Quality
+
+AI-produced content is acceptable (Google March 2024) when it shows genuine E-E-A-T.
+
+**Low-quality AI content flags:**
+- Generic phrasing: "In today's fast-paced world...", "It's important to note..."
+- No original insight — only rephrases widely available information
+- Perfect structure with shallow content beneath headings
+- Repetitive conclusions, hedging overload ("generally speaking", "it depends on factors")
+- Zero first-person examples, no data, no named sources
+
+**High-quality signals regardless of production method:**
+- Original data (surveys, benchmarks, experiments)
+- Named specific examples (companies, dates, numbers)
+- Contrarian or nuanced views backed by reasoning
+- Practical, specific recommendations with acknowledged trade-offs
+
+---
+
+## Topical Authority Modifier
+
+| Level | Criteria | Modifier |
+|---|---|---|
+| Authority | 20+ pages covering topic comprehensively, strong internal linking clusters | +10 |
+| Developing | 10–20 pages, some clustering | +5 |
+| Emerging | 5–10 pages, limited clustering | +0 |
+| Thin | < 5 pages, no clustering | −5 |
+
+---
+
+## Score Interpretation
+
+| Range | Rating |
 |---|---|
-| Original data | Surveys, experiments, benchmarks, proprietary analysis |
-| Specific examples | Named products, companies, dates, numbers |
-| Contrarian or nuanced views | Disagreement with conventional wisdom, backed by reasoning |
-| First-person experience | "When I tested this..." or "Our team found..." |
-| Updated information | References to recent events, current data |
-| Expert opinion | Clear professional judgment, not just facts |
-| Practical recommendations | Specific, actionable advice, not vague guidance |
-| Trade-offs acknowledged | "This approach works well for X but not for Y because..." |
+| 85–100 | Exceptional — strong AI citation candidate |
+| 70–84 | Good — solid foundation |
+| 55–69 | Average — multiple E-E-A-T gaps |
+| 40–54 | Below Average — significant content issues |
+| 0–39 | Poor — fundamental overhaul needed |
 
 ---
 
-## Content Freshness Assessment
+## Worker Return Format
 
-### Publication Dates
-- Check for visible `datePublished` and `dateModified` in both the content and structured data
-- Content without dates is treated as less trustworthy by AI platforms
-- Dates should be specific (January 15, 2026) not vague ("recently")
-
-### Freshness Scoring
-
-| Criterion | Score |
-|---|---|
-| Updated within 3 months | Excellent — current and relevant |
-| Updated within 6 months | Good — still reasonably current |
-| Updated within 12 months | Acceptable — may need refresh |
-| Updated 12-24 months ago | Warning — review for accuracy |
-| No date or 24+ months old | Critical — AI platforms may deprioritize |
-
-### Evergreen Indicators
-Some content remains relevant regardless of age. Flag content as evergreen if:
-- It covers fundamental concepts that do not change (physics, basic math, legal definitions)
-- It is clearly labeled as a reference/guide for lasting concepts
-- It does not contain time-dependent claims ("the latest", "currently", "in 2024")
-
----
-
-## Topical Authority Assessment
-
-### What It Is
-Topical authority measures whether a site comprehensively covers a topic rather than touching on it superficially. AI platforms prefer citing sites that are recognized authorities on their topics.
-
-### How to Assess
-1. **Content breadth**: Does the site have multiple pages covering different aspects of its core topic?
-2. **Content depth**: Do individual pages go deep into subtopics?
-3. **Topic clustering**: Are pages organized into logical groups with internal linking?
-4. **Content gaps**: Are there obvious subtopics that the site should cover but does not?
-5. **Competitor comparison**: Do competitors cover subtopics that this site misses?
-
-### Scoring
-
-| Level | Description | Score Impact |
-|---|---|---|
-| Authority | 20+ pages covering topic comprehensively, strong clustering | +10 bonus |
-| Developing | 10-20 pages with some clustering | +5 bonus |
-| Emerging | 5-10 pages on topic, limited clustering | +0 |
-| Thin | < 5 pages, no clustering | -5 penalty |
-
----
-
-## Overall Scoring (0-100)
-
-### Score Composition
-| Component | Weight | Max Points |
-|---|---|---|
-| Experience | 25% | 25 |
-| Expertise | 25% | 25 |
-| Authoritativeness | 25% | 25 |
-| Trustworthiness | 25% | 25 |
-| **Subtotal** | | **100** |
-| Topical Authority Modifier | | +10 to -5 |
-| **Final Score** | | **Capped at 100** |
-
-### Score Interpretation
-- **85-100**: Exceptional — strong AI citation candidate across platforms
-- **70-84**: Good — solid foundation, specific improvements will increase citability
-- **55-69**: Average — multiple E-E-A-T gaps reducing AI visibility
-- **40-54**: Below Average — significant content quality and trust issues
-- **0-39**: Poor — fundamental content strategy overhaul needed
-
----
-
-## Output Format
-
-Generate **GEO-CONTENT-ANALYSIS.md** with:
-
-```markdown
-# GEO Content Quality & E-E-A-T Analysis — [Domain]
-Date: [Date]
-
-## Content Score: XX/100
-
-## E-E-A-T Breakdown
-| Dimension | Score | Key Finding |
-|---|---|---|
-| Experience | XX/25 | [One-line summary] |
-| Expertise | XX/25 | [One-line summary] |
-| Authoritativeness | XX/25 | [One-line summary] |
-| Trustworthiness | XX/25 | [One-line summary] |
-
-## Topical Authority Modifier: [+10 to -5]
-
-## Pages Analyzed
-| Page | Word Count | Readability | Heading Structure | Citability Rating |
-|---|---|---|---|---|
-| [URL] | [Count] | [Score] | [Pass/Warn/Fail] | [High/Medium/Low] |
-
-## E-E-A-T Detailed Findings
-
-### Experience
-[Specific passages and pages with strong/weak experience signals]
-
-### Expertise
-[Author credentials found, technical depth assessment, specific gaps]
-
-### Authoritativeness
-[External validation found, topical authority assessment, gaps]
-
-### Trustworthiness
-[Trust signals present/missing, accuracy concerns if any]
-
-## Content Quality Issues
-[Specific passages flagged with reasons and rewrite suggestions]
-
-## AI Content Concerns
-[Any low-quality AI content patterns detected, with specific examples]
-
-## Freshness Assessment
-| Page | Published | Last Updated | Status |
-|---|---|---|---|
-| [URL] | [Date] | [Date] | [Current/Stale/No Date] |
-
-## Citability Assessment
-### Most Citable Passages
-[Top 5 passages that AI platforms are most likely to cite, with reasons]
-
-### Least Citable Pages
-[Pages with lowest citability, with specific improvement recommendations]
-
-## Improvement Recommendations
-### Quick Wins
-[Specific content changes that can be made immediately]
-
-### Content Gaps
-[Topics the site should cover to strengthen topical authority]
-
-### Author/E-E-A-T Improvements
-[Specific steps to strengthen E-E-A-T signals]
+```json
+{
+  "score": 44,
+  "critical_3": [
+    "No author attribution on any content page — AI systems cannot assess expertise",
+    "All blog posts lack publication dates — treated as stale by freshness-sensitive AI platforms",
+    "About page 87 words — insufficient for trust signals or expertise demonstration"
+  ],
+  "quick_wins_3": [
+    "Add author byline with credentials to all blog posts",
+    "Add datePublished and dateModified to every content page (visible + schema)",
+    "Expand About page to 500+ words: founding story, team credentials, mission"
+  ]
+}
 ```

--- a/skills/geo-crawlers/SKILL.md
+++ b/skills/geo-crawlers/SKILL.md
@@ -1,177 +1,104 @@
 ---
 name: geo-crawlers
-description: AI crawler access analysis. Checks robots.txt, meta tags, and HTTP headers to determine which AI crawlers can access the site. Provides a complete access map and recommendations for maximizing AI visibility while maintaining appropriate control.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - WebFetch
-  - Write
+description: >
+  AI crawler access analysis. Parses robots.txt and checks meta robots tags and HTTP
+  headers to map which AI crawlers can access the site. Produces a crawler access map
+  and a ready-to-paste robots.txt recommendation. Invoked directly via /geo crawlers
+  or as a parallel worker in /geo audit.
 ---
 
-# AI Crawler Access Analysis Skill
+# GEO Crawler Access Analyser
 
 ## Purpose
 
-This skill analyzes a website's accessibility to AI crawlers -- the bots that AI companies use to discover, index, and train on web content. If AI crawlers are blocked, the site's content cannot appear in AI-generated responses regardless of its quality. Crawler access is the foundational technical requirement for GEO.
+Map AI crawler access from robots.txt. A blocked AI crawler means zero visibility on
+that platform, regardless of content quality.
 
-## Key Insight
-
-As of early 2026, many websites inadvertently block AI crawlers through overly aggressive robots.txt rules, inherited from legacy SEO configurations. An Originality.ai 2025 study found that over 35% of the top 1,000 websites block at least one major AI crawler, and 5-10% block all AI crawlers. Blocking AI crawlers is the single fastest way to become invisible in AI-generated search results.
-
----
-
-## Complete AI Crawler Reference
-
-### Tier 1: Critical for AI Search Visibility (RECOMMEND: ALLOW)
-
-These crawlers power the AI search products where users actively look for answers. Blocking them directly reduces your visibility in AI-generated responses.
-
-#### GPTBot
-- **Operator:** OpenAI
-- **User-Agent:** `GPTBot`
-- **Full User-Agent String:** `Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.2; +https://openai.com/gptbot)`
-- **Purpose:** Fetches content for ChatGPT's web browsing, plugins, and search features. Content accessed by GPTBot may be used to improve OpenAI models.
-- **Impact of Blocking:** Content will NOT appear in ChatGPT Search results or be accessible when users ask ChatGPT to browse the web. This is the highest-impact AI crawler to allow.
-- **Recommendation:** **ALLOW** -- ChatGPT has 300M+ weekly active users as of 2025. Blocking GPTBot removes your content from one of the largest AI search surfaces.
-
-#### OAI-SearchBot
-- **Operator:** OpenAI
-- **User-Agent:** `OAI-SearchBot`
-- **Full User-Agent String:** `Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; OAI-SearchBot/1.0; +https://docs.openai.com/bots/overview)`
-- **Purpose:** Specifically powers ChatGPT's search feature. Unlike GPTBot, content accessed by OAI-SearchBot is NOT used for model training -- only for live search results.
-- **Impact of Blocking:** Content will not appear in ChatGPT's search results even if GPTBot is allowed.
-- **Recommendation:** **ALLOW** -- This is a search-only crawler with no training implications. There is no strategic reason to block it.
-
-#### ChatGPT-User
-- **Operator:** OpenAI
-- **User-Agent:** `ChatGPT-User`
-- **Full User-Agent String:** `Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ChatGPT-User/1.0; +https://openai.com/bot)`
-- **Purpose:** Used when a ChatGPT user explicitly asks the model to visit a specific URL. Acts like a browser agent on behalf of the user.
-- **Impact of Blocking:** ChatGPT cannot visit your pages when users ask it to read or summarize them. This prevents direct user-initiated traffic.
-- **Recommendation:** **ALLOW** -- Blocking this bot prevents users who are actively trying to engage with your content from accessing it through ChatGPT.
-
-#### ClaudeBot
-- **Operator:** Anthropic
-- **User-Agent:** `ClaudeBot`
-- **Full User-Agent String:** `ClaudeBot/1.0; +https://www.anthropic.com/claude-bot`
-- **Purpose:** Fetches web content for Claude's features including web search, citations, and analysis tools.
-- **Impact of Blocking:** Content will not be accessible to Claude for web search or when users ask Claude to analyze specific URLs.
-- **Recommendation:** **ALLOW** -- Claude is a major AI assistant with growing market share. Blocking ClaudeBot reduces your AI search footprint.
-
-#### PerplexityBot
-- **Operator:** Perplexity AI
-- **User-Agent:** `PerplexityBot`
-- **Full User-Agent String:** `Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)`
-- **Purpose:** Powers Perplexity's AI search engine, which provides sourced answers with direct citations and links back to source pages.
-- **Impact of Blocking:** Content will not appear in Perplexity search results. Perplexity is one of the best referral traffic sources among AI search products because it always displays source links.
-- **Recommendation:** **ALLOW** -- Perplexity drives actual referral traffic and always attributes sources. High-value AI crawler for publishers and businesses.
+**This worker's domain:** robots.txt and page-level crawler directives only.
+llms.txt presence and validity is handled by `geo-llmstxt`.
 
 ---
 
-### Tier 2: Important for Broader AI Ecosystem (RECOMMEND: ALLOW)
+## AI Crawler Reference
 
-These crawlers serve large AI platforms or search ecosystems. Allowing them increases your content's reach.
+### Tier 1 — Critical for AI Search (RECOMMEND: ALLOW)
 
-#### Google-Extended
-- **Operator:** Google
-- **User-Agent:** `Google-Extended`
-- **Purpose:** Controls whether Google uses your content for Gemini model training and AI Overviews improvement. **CRITICAL NOTE:** Blocking Google-Extended does NOT affect your Google Search rankings or your appearance in Google Search results. That is controlled by the standard Googlebot.
-- **Impact of Blocking:** Content may not be used for Gemini training or to improve AI Overviews. However, your content can still appear in AI Overviews based on standard search indexing.
-- **Recommendation:** **ALLOW** -- Blocking provides minimal content protection upside while reducing your presence in Google's AI features. Since it does not affect standard search ranking, the only reason to block is philosophical objection to training data usage.
-
-#### GoogleOther
-- **Operator:** Google
-- **User-Agent:** `GoogleOther`
-- **Purpose:** Used by Google for various non-search-ranking purposes including research, one-off crawls, and AI-related data collection.
-- **Impact of Blocking:** Minimal impact on search rankings. May reduce presence in Google's AI research and experimental features.
-- **Recommendation:** **ALLOW** -- Low risk, moderate potential benefit for AI feature inclusion.
-
-#### Applebot-Extended
-- **Operator:** Apple
-- **User-Agent:** `Applebot-Extended`
-- **Purpose:** Used by Apple to train and improve Apple Intelligence features, Siri, and Apple's AI products. Separate from standard Applebot (which powers Siri search and Spotlight Suggestions).
-- **Impact of Blocking:** Content may not be used in Apple Intelligence features. Standard Siri and Spotlight functionality is unaffected (controlled by Applebot).
-- **Recommendation:** **ALLOW** -- Apple Intelligence is integrated into all Apple devices (2B+ active devices). Presence in Apple's AI features has growing strategic value.
-
-#### Amazonbot
-- **Operator:** Amazon
-- **User-Agent:** `Amazonbot`
-- **Full User-Agent String:** `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (compatible; Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)`
-- **Purpose:** Indexes content for Alexa answers and Amazon's AI features.
-- **Impact of Blocking:** Content will not appear in Alexa voice responses or Amazon's AI-powered search features.
-- **Recommendation:** **ALLOW** -- Relevant for voice search optimization. Lower priority than Tier 1 crawlers but no downside to allowing.
-
-#### FacebookBot
-- **Operator:** Meta
-- **User-Agent:** `FacebookBot`
-- **Purpose:** Used by Meta for AI features across Facebook, Instagram, WhatsApp, and Meta AI assistant.
-- **Impact of Blocking:** Content may not be accessible to Meta AI. Link previews on Facebook/Instagram are handled by a different crawler and are unaffected.
-- **Recommendation:** **ALLOW** -- Meta AI is embedded in apps with 3B+ combined users. Growing importance for AI visibility.
-
----
-
-### Tier 3: Training-Only Crawlers (ALLOW or BLOCK Based on Strategy)
-
-These crawlers are primarily used for AI model training rather than live search features. Blocking them does not affect AI search visibility.
-
-#### CCBot
-- **Operator:** Common Crawl (nonprofit)
-- **User-Agent:** `CCBot`
-- **Full User-Agent String:** `CCBot/2.0 (https://commoncrawl.org/faq/)`
-- **Purpose:** Builds the Common Crawl dataset, which is used as training data by many AI companies (Google, Meta, Stability AI, and others).
-- **Impact of Blocking:** Content will not appear in future Common Crawl datasets. Does NOT affect any live AI search product.
-- **Recommendation:** **CONTEXT-DEPENDENT** -- Allow if you want maximum long-term AI training presence. Block if you want to control training data usage. No impact on search visibility.
-
-#### anthropic-ai
-- **Operator:** Anthropic
-- **User-Agent:** `anthropic-ai`
-- **Purpose:** Used by Anthropic for AI safety research and Claude model training. Separate from ClaudeBot (which powers live features).
-- **Impact of Blocking:** Content will not be used for Claude training. Does NOT affect Claude's live search or web browsing features (controlled by ClaudeBot).
-- **Recommendation:** **CONTEXT-DEPENDENT** -- Similar to CCBot. Allow for training presence, block for training data control. No impact on live AI search.
-
-#### Bytespider
-- **Operator:** ByteDance
-- **User-Agent:** `Bytespider`
-- **Purpose:** Used by ByteDance for various AI products including TikTok's AI features and Doubao (their ChatGPT competitor in China).
-- **Impact of Blocking:** Content will not be used for ByteDance AI products. Minimal impact for Western-market businesses.
-- **Recommendation:** **BLOCK** for most Western businesses (aggressive crawling behavior reported, minimal search visibility benefit). **ALLOW** if targeting Chinese/Asian markets.
-
-#### cohere-ai
-- **Operator:** Cohere
-- **User-Agent:** `cohere-ai`
-- **Purpose:** Used by Cohere for model training. Cohere powers enterprise AI solutions and the Coral chat product.
-- **Impact of Blocking:** Content will not be used for Cohere model training. Minimal direct consumer-facing impact.
-- **Recommendation:** **CONTEXT-DEPENDENT** -- Low priority. Allow or block based on general training data stance.
-
----
-
-## Recommendation Matrix Summary
-
-| Crawler | Tier | Recommendation | Reason |
+| Crawler | User-Agent | Platform | Impact if blocked |
 |---|---|---|---|
-| GPTBot | 1 | **ALLOW** | Powers ChatGPT Search (300M+ users) |
-| OAI-SearchBot | 1 | **ALLOW** | Search-only, no training use |
-| ChatGPT-User | 1 | **ALLOW** | User-initiated browsing |
-| ClaudeBot | 1 | **ALLOW** | Claude web search and analysis |
-| PerplexityBot | 1 | **ALLOW** | Best referral traffic AI search |
-| Google-Extended | 2 | **ALLOW** | Gemini features; no search rank impact |
-| GoogleOther | 2 | **ALLOW** | Google AI research |
-| Applebot-Extended | 2 | **ALLOW** | Apple Intelligence (2B+ devices) |
-| Amazonbot | 2 | **ALLOW** | Alexa and Amazon AI |
-| FacebookBot | 2 | **ALLOW** | Meta AI (3B+ app users) |
-| CCBot | 3 | Context | Training data only |
-| anthropic-ai | 3 | Context | Training data only |
-| Bytespider | 3 | **BLOCK** | Aggressive crawler, low benefit |
-| cohere-ai | 3 | Context | Training data only |
+| GPTBot | `GPTBot` | ChatGPT Search | Not cited in ChatGPT Search |
+| OAI-SearchBot | `OAI-SearchBot` | ChatGPT Search (no training) | Not in ChatGPT search results |
+| ChatGPT-User | `ChatGPT-User` | User-initiated ChatGPT browsing | ChatGPT cannot visit page on user request |
+| ClaudeBot | `ClaudeBot` | Claude web search | Not accessible to Claude |
+| PerplexityBot | `PerplexityBot` | Perplexity AI | Not cited in Perplexity (best AI referral traffic) |
 
-### Maximum AI Visibility Configuration (robots.txt)
+### Tier 2 — Important Ecosystem (RECOMMEND: ALLOW)
 
-For sites wanting maximum AI search visibility:
+| Crawler | User-Agent | Platform |
+|---|---|---|
+| Google-Extended | `Google-Extended` | Gemini training + AI Overviews (NOT standard search rank) |
+| GoogleOther | `GoogleOther` | Google AI research |
+| Applebot-Extended | `Applebot-Extended` | Apple Intelligence (2B+ devices) |
+| Amazonbot | `Amazonbot` | Alexa + Amazon AI |
+| FacebookBot | `FacebookBot` | Meta AI (3B+ app users) |
+
+### Tier 3 — Training Only (context-dependent)
+
+| Crawler | User-Agent | Recommendation |
+|---|---|---|
+| CCBot | `CCBot` | Context — allow for training presence, block for data control |
+| anthropic-ai | `anthropic-ai` | Context — Claude training only, not live search |
+| Bytespider | `Bytespider` | BLOCK — aggressive crawling, low benefit for Western markets |
+| cohere-ai | `cohere-ai` | Context — low consumer-facing impact |
+
+---
+
+## Analysis Procedure
+
+1. Fetch `[domain]/robots.txt`
+2. For each AI crawler above: determine effective access (explicit Allow / explicit
+   Disallow / wildcard inheritance)
+3. Sample 5 key pages for `<meta name="robots">` and `X-Robots-Tag` headers
+4. Check for `noai` and `noimageai` directives
+5. Check for `Sitemap:` directive in robots.txt
+6. Assess JavaScript rendering requirements for AI crawlers (AI crawlers do NOT execute JS)
+
+---
+
+## Scoring (0–100)
+
+| Component | Weight | Scoring |
+|---|---|---|
+| Tier 1 crawlers allowed | 50% | 20 pts per allowed Tier 1 crawler (5 max = 100, scaled to 50) |
+| Tier 2 crawlers allowed | 25% | 20 pts per allowed Tier 2 crawler (5 max = 100, scaled to 25) |
+| No blanket AI blocks | 15% | Full if no `User-agent: *` Disallow: / and no noai meta tags |
+| AI-specific files present | 10% | 5 pts for llms.txt accessible, 5 pts for sitemap in robots.txt |
+
+---
+
+## Worker Return Format
+
+```json
+{
+  "score": 64,
+  "critical_3": [
+    "GPTBot is blocked via User-agent: * Disallow: /",
+    "PerplexityBot explicitly blocked in robots.txt",
+    "No Sitemap directive in robots.txt — AI crawlers cannot discover pages"
+  ],
+  "quick_wins_3": [
+    "Add 'User-agent: GPTBot\\nAllow: /' to robots.txt",
+    "Remove PerplexityBot Disallow block",
+    "Add 'Sitemap: https://example.com/sitemap.xml' to robots.txt"
+  ]
+}
+```
+
+---
+
+## Recommended robots.txt (Maximum AI Visibility)
 
 ```
-# AI Crawlers - ALLOWED for AI search visibility
+# AI Crawlers — allowed for AI search visibility
 User-agent: GPTBot
 Allow: /
 
@@ -205,7 +132,7 @@ Allow: /
 User-agent: FacebookBot
 Allow: /
 
-# AI Crawlers - BLOCKED (aggressive/low value)
+# AI Crawlers — blocked (aggressive / low value)
 User-agent: Bytespider
 Disallow: /
 
@@ -213,133 +140,4 @@ User-agent: CCBot
 Disallow: /
 ```
 
----
-
-## Analysis Procedure
-
-### Step 1: Fetch and Parse robots.txt
-
-1. Use WebFetch to retrieve `[domain]/robots.txt`.
-2. Parse all User-agent directives and their associated Allow/Disallow rules.
-3. For each AI crawler in the reference list above:
-   - Check if there is a specific User-agent block for that crawler
-   - Check if there is a wildcard (`User-agent: *`) block that would apply
-   - Determine effective access: **Allowed**, **Blocked**, or **Not Mentioned** (inherits wildcard rules)
-4. Note any `Crawl-delay` directives that may slow AI crawler access.
-5. Check for `Sitemap` directives (AI crawlers use these for discovery).
-
-### Step 2: Check Meta Robots Tags
-
-1. For a sample of 5-10 key pages, fetch the HTML and check for:
-   - `<meta name="robots" content="noindex">` -- blocks all bots
-   - `<meta name="robots" content="nofollow">` -- prevents link following
-   - `<meta name="robots" content="noai">` -- emerging tag to block AI use
-   - `<meta name="robots" content="noimageai">` -- blocks AI image training
-   - Bot-specific meta tags: `<meta name="GPTBot" content="noindex">`
-2. Record any page-level overrides of the robots.txt directives.
-
-### Step 3: Check HTTP Headers
-
-1. For the same sample pages, check response headers for:
-   - `X-Robots-Tag: noindex` -- HTTP header equivalent of meta noindex
-   - `X-Robots-Tag: noai` -- HTTP header to block AI use
-   - `X-Robots-Tag: noimageai` -- blocks AI image training
-   - Bot-specific headers: `X-Robots-Tag: GPTBot: noindex`
-2. Note that HTTP headers override meta tags and apply to non-HTML resources too.
-
-### Step 4: Check for AI-Specific Files
-
-1. Check for `/llms.txt` (emerging standard for AI crawler guidance).
-2. Check for `/.well-known/ai-plugin.json` (OpenAI plugin manifest).
-3. Check for `/ai.txt` (proposed standard, similar to ads.txt for AI).
-4. Record presence/absence and quality of each file.
-
-### Step 5: Assess JavaScript Rendering Requirements
-
-1. Check if the site is a Single Page Application (SPA) or heavily JavaScript-rendered.
-2. AI crawlers vary in their JavaScript rendering capabilities:
-   - GPTBot: Limited JS rendering
-   - ClaudeBot: Limited JS rendering
-   - PerplexityBot: Limited JS rendering
-   - Googlebot: Full JS rendering (but Google-Extended inherits this)
-3. If critical content requires JS rendering, flag this as a potential issue.
-4. Check for Server-Side Rendering (SSR) or Static Site Generation (SSG) as mitigations.
-
----
-
-## Output Format
-
-Generate a file called `GEO-CRAWLER-ACCESS.md`:
-
-```markdown
-# AI Crawler Access Report: [Domain]
-
-**Analysis Date:** [Date]
-**Domain:** [Domain]
-**robots.txt Status:** [Found/Not Found/Error]
-
----
-
-## Crawler Access Summary
-
-| Crawler | Operator | Tier | Status | Impact |
-|---|---|---|---|---|
-| GPTBot | OpenAI | 1 | [Allowed/Blocked/Not Mentioned] | [Impact description] |
-| OAI-SearchBot | OpenAI | 1 | [Status] | [Impact] |
-| ChatGPT-User | OpenAI | 1 | [Status] | [Impact] |
-| ClaudeBot | Anthropic | 1 | [Status] | [Impact] |
-| PerplexityBot | Perplexity | 1 | [Status] | [Impact] |
-| Google-Extended | Google | 2 | [Status] | [Impact] |
-| GoogleOther | Google | 2 | [Status] | [Impact] |
-| Applebot-Extended | Apple | 2 | [Status] | [Impact] |
-| Amazonbot | Amazon | 2 | [Status] | [Impact] |
-| FacebookBot | Meta | 2 | [Status] | [Impact] |
-| CCBot | Common Crawl | 3 | [Status] | [Impact] |
-| anthropic-ai | Anthropic | 3 | [Status] | [Impact] |
-| Bytespider | ByteDance | 3 | [Status] | [Impact] |
-| cohere-ai | Cohere | 3 | [Status] | [Impact] |
-
-## AI Visibility Score: [X]/100
-
-**Tier 1 Access:** [X/5 crawlers allowed]
-**Tier 2 Access:** [X/5 crawlers allowed]
-**Tier 3 Access:** [X/4 crawlers allowed]
-
----
-
-## Critical Issues
-
-[List any Tier 1 crawlers that are blocked]
-
-## Recommendations
-
-### Immediate Actions
-[Specific robots.txt changes needed]
-
-### robots.txt Recommendation
-```
-[Complete recommended robots.txt content for AI crawlers]
-```
-
-### Additional Technical Findings
-- **Meta Robots Tags:** [Findings]
-- **X-Robots-Tag Headers:** [Findings]
-- **JavaScript Rendering:** [Assessment]
-- **llms.txt:** [Present/Absent]
-- **Sitemap Accessibility:** [Assessment]
-```
-
----
-
-## Scoring for Crawler Access
-
-The AI Crawler Access Score is calculated as:
-
-| Component | Weight | Scoring |
-|---|---|---|
-| Tier 1 Crawlers Allowed | 50% | 20 points per Tier 1 crawler allowed (5 crawlers = 100 points max, scaled to 50) |
-| Tier 2 Crawlers Allowed | 25% | 20 points per Tier 2 crawler allowed (5 crawlers = 100 points max, scaled to 25) |
-| No Blanket AI Blocks | 15% | Full points if no `User-agent: *` Disallow: / and no noai meta tags |
-| AI-Specific Files Present | 10% | 5 points for llms.txt, 5 points for sitemap accessible to AI crawlers |
-
-Final score = sum of all weighted components, capped at 100.
+Emit this as a code block when relevant crawlers are blocked.

--- a/skills/geo-llmstxt/SKILL.md
+++ b/skills/geo-llmstxt/SKILL.md
@@ -1,432 +1,152 @@
 ---
 name: geo-llmstxt
-description: Analyzes and generates llms.txt files -- the emerging standard for helping AI systems understand website structure and content. Can validate existing llms.txt files or generate new ones from scratch by crawling the site.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - WebFetch
-  - Write
+description: >
+  llms.txt presence, validity, and generation. Validates an existing llms.txt file or
+  generates a new one from scratch by crawling site structure. Generated files are
+  displayed as inline code blocks — not written to disk. Invoked directly via
+  /geo llmstxt or as a parallel worker in /geo audit.
 ---
 
-# llms.txt Standard Analysis and Generation Skill
+# GEO llms.txt Analyser and Generator
 
 ## Purpose
 
-This skill handles everything related to the `llms.txt` standard -- an emerging convention (proposed by Jeremy Howard in September 2024, gaining adoption through 2025-2026) that allows websites to provide structured guidance to AI systems about their content, structure, and key information. It is analogous to `robots.txt` (which tells crawlers what NOT to access) but instead tells AI systems what IS most useful to understand about the site.
+Validate or generate an `llms.txt` file — the emerging standard (proposed by Jeremy Howard,
+September 2024) that tells AI systems what content on a site is most useful to understand.
 
-## Why llms.txt Matters
-
-AI language models face a fundamental challenge when processing websites: they must determine which pages are most important, what the site is about, and how content is organized -- typically by crawling many pages and inferring structure. `llms.txt` solves this by providing an explicit, machine-readable (and human-readable) summary.
-
-**Benefits of having a well-crafted llms.txt:**
-
-1. **Faster AI comprehension:** AI systems can understand your site's purpose and structure from a single file rather than crawling dozens of pages.
-2. **Controlled narrative:** You choose which pages and facts AI systems see first, shaping how they represent your brand.
-3. **Higher citation accuracy:** AI systems that consult llms.txt can cite the correct, authoritative page for each topic.
-4. **Reduced misrepresentation:** Key facts (pricing, features, locations) are stated explicitly, reducing AI hallucination about your business.
-5. **Early adopter advantage:** As of early 2026, fewer than 5% of websites have an llms.txt file, making it a differentiator.
+**This worker's domain:** `/llms.txt` and `/llms-full.txt` only.
+AI crawler access (robots.txt) is handled by `geo-crawlers`.
 
 ---
 
-## The llms.txt Specification
+## Script
 
-### File Location
+```bash
+# Validate existing llms.txt
+node {baseDir}/scripts/llmstxt-generator.mjs --mode validate --url <url>
 
-The file MUST be located at the root of the domain:
+# Generate new llms.txt from site structure
+node {baseDir}/scripts/llmstxt-generator.mjs --mode generate --url <url>
 ```
-https://example.com/llms.txt
+
+Outputs JSON to stdout:
+```json
+{
+  "status": "found|not_found|error",
+  "score": 74,
+  "issues": ["Missing Key Facts section", "3 URLs return 404"],
+  "generated": "# Site Name\n> Description...\n..."
+}
 ```
 
-### Format Specification
+---
 
-The file uses Markdown formatting with specific conventions:
+## llms.txt Format Specification
 
 ```markdown
 # [Site Name]
 
-> [One-sentence description of what the site/business does. Keep under 200 characters.]
+> [One sentence: what the site does, who it serves, key value. Under 200 characters.]
 
-## Docs
+## [Section — e.g. Docs, Products, Resources, Blog]
 
-- [Page Title](https://example.com/page-url): Concise description of what this page covers and why it matters.
-- [Another Page](https://example.com/another-page): Description of content.
-
-## Optional
-
-- [Less Critical Page](https://example.com/optional-page): Description.
-```
-
-### Detailed Format Rules
-
-**1. Title (Required)**
-```markdown
-# Site Name
-```
-- Must be the first line of the file.
-- Should be the official business/site name.
-- Use the H1 heading format (single `#`).
-
-**2. Description (Required)**
-```markdown
-> Brief description of the site/business
-```
-- Must appear immediately after the title.
-- Use Markdown blockquote format (`>`).
-- Keep under 200 characters.
-- Should clearly state what the business does and who it serves.
-- Avoid marketing fluff -- be factual and specific.
-
-**3. Main Sections (Required -- at least one)**
-
-Use H2 headings (`##`) to organize pages by category. Common section names:
-
-| Section Name | Purpose | Example Content |
-|---|---|---|
-| `## Docs` | Primary documentation or key pages | Product pages, service descriptions, core content |
-| `## Optional` | Secondary pages worth knowing about | Blog posts, supplementary resources |
-| `## API` | API documentation | API reference, authentication guides |
-| `## Blog` | Blog or news content | Recent/popular articles |
-| `## Products` | Product catalog | Product pages, pricing |
-| `## Services` | Service offerings | Service descriptions, process pages |
-| `## About` | Company information | About page, team, mission |
-| `## Resources` | Educational/reference content | Guides, tutorials, whitepapers |
-| `## Legal` | Legal documents | Terms of service, privacy policy |
-| `## Contact` | Contact information | Contact page, support channels |
-
-**4. Page Entries (Required)**
-
-Each entry follows the format:
-```markdown
-- [Page Title](URL): Description of page content
-```
-
-Rules for page entries:
-- **Title:** Use the actual page title or a clear descriptive title.
-- **URL:** Must be a full, absolute URL (not relative paths).
-- **Description:** 10-30 words describing what the page covers. Be specific about the information available.
-- **Order:** List pages in order of importance within each section.
-- **Limit:** Include 10-30 page entries total. Prioritize your most authoritative and useful pages.
-
-**5. Key Facts Section (Recommended)**
-
-```markdown
-## Key Facts
-- Founded in [year] by [founder(s)]
-- Headquarters: [City, Country]
-- [X] customers/users in [Y] countries
-- Key products: [Product A], [Product B], [Product C]
-- Industry: [Industry classification]
-```
-
-This section provides quick reference data that AI systems frequently need to answer user queries about your business.
-
-**6. Contact Section (Recommended)**
-
-```markdown
-## Contact
-- Website: https://example.com
-- Email: hello@example.com
-- Support: support@example.com
-- Phone: +1-555-123-4567
-- Address: 123 Main St, City, State, ZIP, Country
-```
-
----
-
-## llms-full.txt (Extended Version)
-
-In addition to `llms.txt`, sites can provide `/llms-full.txt` -- an extended version with more detail.
-
-**Differences from llms.txt:**
-
-| Feature | llms.txt | llms-full.txt |
-|---|---|---|
-| **Length** | Concise (50-150 lines) | Comprehensive (150-500+ lines) |
-| **Page entries** | 10-30 key pages | 30-100+ pages |
-| **Descriptions** | 10-30 words per entry | 30-100 words per entry, may include key facts from each page |
-| **Audience** | Quick AI comprehension | Deep AI analysis |
-| **Sections** | 3-6 sections | 8-15 sections |
-| **Key facts** | Business-level facts | Page-level facts and data points |
-
-Both files can coexist. AI systems check for `llms.txt` first, then may optionally load `llms-full.txt` for deeper understanding.
-
----
-
-## Analysis Mode
-
-When checking an existing llms.txt file:
-
-### Step 1: Fetch the File
-
-1. Use WebFetch to retrieve `[domain]/llms.txt`.
-2. Also check for `[domain]/llms-full.txt`.
-3. Record HTTP status code:
-   - **200:** File exists -- proceed to validation.
-   - **404:** File does not exist -- recommend generation.
-   - **403:** File exists but is blocked -- flag as misconfiguration.
-   - **301/302:** Redirect -- follow and note the redirect.
-
-### Step 2: Validate Format
-
-Check each structural element:
-
-| Element | Check | Severity if Missing |
-|---|---|---|
-| H1 Title | Present, matches business name | Critical |
-| Blockquote description | Present, under 200 chars, factual | High |
-| At least one H2 section | Present | Critical |
-| Page entries with URLs | At least 5 entries present | High |
-| URLs are absolute | All URLs use full https:// paths | High |
-| URLs are valid | All URLs return 200 status | Medium |
-| Descriptions present | Every entry has a description after the colon | Medium |
-| Key Facts section | Present with business information | Medium |
-| Contact section | Present with at least email | Low |
-| Reasonable length | 30-200 lines | Low |
-| No broken Markdown | Proper formatting throughout | Medium |
-
-### Step 3: Assess Content Quality
-
-Rate the llms.txt on these dimensions:
-
-**Completeness (0-100):**
-- Does it cover all major site sections visible in the navigation?
-- Are the most important/highest-traffic pages included?
-- Is the Key Facts section present with accurate business data?
-- Does it include recent/updated content?
-
-**Accuracy (0-100):**
-- Do descriptions accurately reflect page content?
-- Are URLs valid and pointing to the correct pages?
-- Are Key Facts verifiable and current?
-- Is the business description accurate?
-
-**Usefulness (0-100):**
-- Would an AI system understand the site's purpose from this file alone?
-- Are descriptions specific enough to differentiate pages?
-- Are the most citation-worthy pages highlighted?
-- Is the organization logical and intuitive?
-
-**Overall llms.txt Score** = (Completeness * 0.40) + (Accuracy * 0.35) + (Usefulness * 0.25)
-
-### Step 4: Compare Against Site Content
-
-1. Crawl the site's main navigation and sitemap.
-2. Identify important pages NOT listed in llms.txt.
-3. Check if any listed URLs are broken or redirected.
-4. Verify that the business description matches current homepage messaging.
-5. Flag stale entries (pages that have been significantly updated since the llms.txt was written).
-
----
-
-## Generation Mode
-
-When creating a new llms.txt file from scratch:
-
-### Step 1: Site Discovery
-
-1. Fetch the homepage and extract:
-   - Site name (from `<title>`, `<meta property="og:site_name">`, or H1)
-   - Business description (from meta description or hero section)
-   - Main navigation links
-   - Footer links
-2. Fetch `/sitemap.xml` to discover all public pages.
-3. Identify the site's primary business type (SaaS, E-commerce, Local, Publisher, Agency).
-
-### Step 2: Page Prioritization
-
-Categorize all discovered pages and select the most important ones:
-
-**Always Include:**
-- Homepage
-- About / Company page
-- Pricing page (if exists)
-- Primary product/service pages (top 3-5)
-- Contact page
-- Documentation landing page (if exists)
-
-**Include if High Quality:**
-- Top blog posts (by apparent importance, recency, or comprehensiveness)
-- Case studies or customer stories
-- Key resource/guide pages
-- FAQ page
-- Careers page (for large companies)
-
-**Skip:**
-- Thin category/tag pages
-- Pagination pages
-- Login/signup pages
-- Legal boilerplate (unless specifically relevant)
-- Duplicate or near-duplicate content
-- Pages with minimal unique content
-
-### Step 3: Write Descriptions
-
-For each selected page:
-
-1. Fetch the page content using WebFetch.
-2. Read the H1, meta description, and first 2-3 paragraphs.
-3. Write a description that:
-   - Is 10-30 words long
-   - States what information is on the page
-   - Mentions specific topics, data, or features covered
-   - Avoids marketing language ("best," "leading," "revolutionary")
-   - Uses factual, informative language
-
-**Good description examples:**
-- `Explains the three pricing tiers (Free, Pro, Enterprise) with feature comparison and annual/monthly costs.`
-- `Details the company's founding in 2018, team of 45 employees, and office locations in Austin and London.`
-- `Covers integration setup for Slack, Salesforce, and HubSpot with step-by-step guides and API endpoints.`
-
-**Bad description examples:**
-- `Our amazing pricing page!` (marketing language, no specifics)
-- `Learn more about our company.` (too vague)
-- `Click here for details.` (not descriptive)
-
-### Step 4: Compile Key Facts
-
-Gather key business facts from the site:
-
-- Year founded
-- Founder name(s)
-- Headquarters location
-- Number of employees (if public)
-- Number of customers/users (if public)
-- Key products or services (list top 3-5)
-- Industry classification
-- Notable clients or partnerships (if public)
-- Key differentiators (what makes this business unique)
-- Recent milestones or achievements (last 12 months)
-
-### Step 5: Assemble the File
-
-Construct the llms.txt following this template:
-
-```markdown
-# [Site Name]
-
-> [One clear sentence: what the business does, who it serves, and its primary value proposition. Under 200 characters.]
-
-## Docs
-
-- [Most Important Page](https://example.com/page): Description covering the key content on this page.
-- [Second Page](https://example.com/page-2): Description of this page's content and value.
-- [Third Page](https://example.com/page-3): What users and AI systems will find here.
-
-## Products
-
-- [Product A](https://example.com/product-a): Core features, target users, and pricing model for Product A.
-- [Product B](https://example.com/product-b): What Product B does and how it differs from Product A.
-
-## Resources
-
-- [Guide Title](https://example.com/guide): Comprehensive guide covering [topic] with [X] sections and practical examples.
-- [Blog Post](https://example.com/blog/post): Analysis of [topic] with original data from [source].
+- [Page Title](https://example.com/page): 10–30 word description of what this page covers.
+- [Another Page](https://example.com/page-2): What information is here and why it matters.
 
 ## Key Facts
 
 - Founded in [year] by [name(s)]
 - Headquartered in [City, Country]
-- [Specific metric: e.g., "Serves 10,000+ businesses in 40 countries"]
-- [Key differentiator: e.g., "Only platform offering real-time X and Y integration"]
+- [Specific metric: "Serves 10,000+ businesses in 40 countries"]
 - Industry: [Classification]
 
 ## Contact
 
 - Website: https://example.com
-- Email: [primary contact email]
-- Support: [support URL or email]
+- Email: contact@example.com
 ```
 
-### Step 6: Validate the Generated File
+### Format Rules
 
-Before outputting:
-1. Verify all URLs are reachable (200 status).
-2. Confirm total entry count is between 10-30.
-3. Check that no description exceeds 50 words.
-4. Verify the overall file length is 50-150 lines.
-5. Ensure Markdown formatting is clean and consistent.
-
----
-
-## Output Format
-
-### For Analysis Mode
-
-Generate `GEO-LLMSTXT-ANALYSIS.md`:
-
-```markdown
-# llms.txt Analysis: [Domain]
-
-**Analysis Date:** [Date]
-**llms.txt Status:** [Found at URL / Not Found / Error]
-**llms-full.txt Status:** [Found / Not Found]
+- **Title:** H1 (`#`), first line, official site/business name
+- **Description:** Blockquote (`>`), immediately after title, under 200 characters, factual
+- **Sections:** H2 (`##`) — Docs, Products, Services, Resources, Blog, About, Legal, Contact
+- **Entries:** `- [Title](absolute-URL): description`
+- **Entry count:** 10–30 total across all sections
+- **Descriptions:** 10–30 words, specific, no marketing language
+- **URLs:** Absolute only — never relative paths
+- **Length:** 50–150 lines
 
 ---
 
-## Overall llms.txt Score: [X]/100
+## Validation Checklist
 
-| Dimension | Score |
+| Element | Severity if absent |
 |---|---|
-| Completeness | [X]/100 |
-| Accuracy | [X]/100 |
-| Usefulness | [X]/100 |
+| H1 title | Critical |
+| Blockquote description (< 200 chars) | High |
+| At least one H2 section | Critical |
+| Minimum 5 page entries | High |
+| All URLs absolute (https://) | High |
+| All URLs return 200 | Medium |
+| Descriptions on every entry | Medium |
+| Key Facts section | Medium |
+| Contact section | Low |
+| File length 30–200 lines | Low |
+| No broken Markdown | Medium |
 
 ---
 
-## Format Validation
+## Scoring (0–100)
 
-| Element | Status | Notes |
-|---|---|---|
-| H1 Title | [Pass/Fail] | [Notes] |
-| Description blockquote | [Pass/Fail] | [Notes] |
-| H2 Sections | [Pass/Fail] | [X sections found] |
-| Page entries | [Pass/Fail] | [X entries found] |
-| URL validity | [Pass/Fail] | [X broken URLs] |
-| Entry descriptions | [Pass/Fail] | [X missing descriptions] |
-| Key Facts | [Pass/Fail] | [Notes] |
-| Contact section | [Pass/Fail] | [Notes] |
+Overall = (Completeness × 0.40) + (Accuracy × 0.35) + (Usefulness × 0.25)
+
+- **Completeness:** Covers all major site sections; includes important pages; Key Facts present
+- **Accuracy:** Descriptions match page content; URLs valid; facts verifiable
+- **Usefulness:** AI system can understand site purpose from file alone; pages well-differentiated
 
 ---
 
-## Missing Pages
+## Page Prioritisation (for generation)
 
-These important pages were found on the site but not in llms.txt:
+**Always include:**
+- Homepage
+- About / Company
+- Pricing (if exists)
+- Top 3–5 product/service pages
+- Contact
 
-1. [Page Title](URL) -- [Why it should be included]
-2. [Page Title](URL) -- [Why it should be included]
+**Include if high quality:**
+- Top blog posts (by depth or recency)
+- Case studies
+- Key guides / resources
+- FAQ page
 
-## Improvement Recommendations
+**Skip:**
+- Thin category/tag/pagination pages
+- Login/signup pages
+- Legal boilerplate (unless specifically relevant)
+- Duplicate or near-duplicate content
 
-1. [Specific recommendation]
-2. [Specific recommendation]
-3. [Specific recommendation]
+---
 
-## Suggested Updated llms.txt
+## Worker Return Format
 
-[Complete rewritten llms.txt file if significant improvements are needed]
+```json
+{
+  "score": 0,
+  "critical_3": [
+    "No llms.txt file found at /llms.txt",
+    "No llms-full.txt alternative present",
+    "AI systems have no structured site overview — must discover by crawling"
+  ],
+  "quick_wins_3": [
+    "Create /llms.txt using generated template below",
+    "Include 10–15 most important page entries with specific descriptions",
+    "Add Key Facts section with founding date, location, and core products"
+  ]
+}
 ```
 
-### For Generation Mode
-
-Output the complete `llms.txt` file content, ready to be saved to the site's root directory. Also output a brief `GEO-LLMSTXT-GENERATION.md` report explaining:
-- How many pages were discovered and how many were selected
-- The prioritization rationale
-- Any pages that were borderline (might add later)
-- Recommended update frequency (e.g., monthly for active blogs, quarterly for stable sites)
-
----
-
-## Best Practices Reference
-
-1. **Update regularly.** If your site publishes weekly blog posts, update llms.txt monthly. If your product changes quarterly, update after each release.
-2. **Lead with your strongest content.** The first entries in each section should be your most authoritative, comprehensive pages.
-3. **Be specific in descriptions.** "Comprehensive 3,000-word guide to React Server Components with code examples" is far more useful than "React guide."
-4. **Include your differentiators.** If your site has unique data, original research, or exclusive features, highlight these in descriptions and Key Facts.
-5. **Keep it concise.** The llms.txt should be scannable in under 60 seconds. Save detail for llms-full.txt.
-6. **Use absolute URLs.** Always include the full `https://` URL, never relative paths.
-7. **Test after deployment.** After uploading, verify the file is accessible at `https://yourdomain.com/llms.txt` with no redirects.
-8. **Coordinate with robots.txt.** Ensure pages listed in llms.txt are not blocked in robots.txt for AI crawlers.
-9. **Mirror your site structure.** Section names in llms.txt should roughly correspond to your main navigation categories.
-10. **Avoid sensitive pages.** Do not include internal tools, admin panels, or pages with sensitive information.
+When a file is generated, emit it as a fenced code block immediately after the worker
+summary so the user can copy and deploy it.

--- a/skills/geo-platform-optimizer/SKILL.md
+++ b/skills/geo-platform-optimizer/SKILL.md
@@ -1,275 +1,84 @@
 ---
 name: geo-platform-optimizer
-description: Platform-specific AI search optimization — audit and optimize for Google AI Overviews, ChatGPT, Perplexity, Gemini, and Bing Copilot individually
-version: 1.0.0
-author: geo-seo-claude
-tags: [geo, ai-search, platform-optimization, chatgpt, perplexity, gemini, aio]
-allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+description: >
+  AI platform-specific optimization analysis. Interprets the combined scores from other
+  workers to produce per-platform readiness assessments for Google AI Overviews, ChatGPT,
+  Perplexity, Gemini, and Bing Copilot. STUB: returns placeholder scores pending
+  issue #2 redesign (input contract definition).
 ---
 
 # GEO Platform Optimizer
 
-## Core Insight
+## Purpose
 
-Only **11% of domains** are cited by BOTH ChatGPT and Google AI Overviews for the same query. Each AI search platform uses different indexes, ranking logic, and source preferences. A page optimized for Google AI Overviews may be invisible to ChatGPT, and vice versa. Platform-specific optimization is not optional — it is the foundation of any serious GEO strategy.
+Interpret how the other 7 worker scores translate to readiness on each AI search platform.
+Each platform uses a different index, ranking logic, and source preference — a score
+optimal for Google AI Overviews may be invisible on ChatGPT.
 
-## How to Use This Skill
-
-1. Collect the target URL and the site's primary topic/industry
-2. Run each platform checklist below against the site
-3. Score each platform on the 0-100 rubric
-4. Generate GEO-PLATFORM-OPTIMIZATION.md with per-platform scores, gaps, and action items
+**This worker's domain:** AI platform-specific interpretation of worker outputs.
+It does NOT re-run detection logic that belongs to other workers.
 
 ---
 
-## Platform 1: Google AI Overviews (AIO)
+## ⚠️ STUB STATUS
 
-### How AIO Selects Sources
-- 92% of AIO citations come from pages already ranking in the **top 10 organic results** — traditional SEO is the gateway
-- However, 47% of citations come from pages ranking **below position 5** — AIO has its own selection logic favoring clarity and directness over raw rank
-- AIO strongly favors pages with **clean structure, direct answers, and scannable formatting**
-- Featured snippet optimization has ~70% overlap with AIO optimization
-- AIO prefers **concise, factual, unambiguous answers** — hedging and filler reduce citation probability
+This worker is a placeholder pending issue #2 resolution.
 
-### Optimization Checklist
+Issue #2 defines: which inputs from the 8 workers feed platform-specific analysis, and
+how to avoid duplicating detection logic already owned by `geo-crawlers`, `geo-schema`,
+`geo-brand-mentions`, etc.
 
-1. **Question-Based Headings**: Use H2/H3 headings phrased as questions matching real user queries. Check Google's "People Also Ask" for the target topic and mirror those exact phrasings.
-2. **Direct Answer in First Paragraph**: After each question heading, provide a clear 1-2 sentence answer immediately. Then expand with supporting detail. The first sentence should be a standalone citation candidate.
-3. **Tables and Structured Comparisons**: AIO heavily cites tables. Convert any comparison, pricing, specification, or feature data into HTML tables. Use clear column headers.
-4. **Ordered and Unordered Lists**: Step-by-step processes should use ordered lists. Feature lists should use unordered lists. AIO extracts these directly.
-5. **FAQ Sections**: Add a dedicated FAQ section with 5-10 real questions. Use proper H3 headings for each question. While FAQPage schema rich results are restricted to govt/health sites since Aug 2023, the content pattern still helps AIO extraction.
-6. **Definitions and Glossary Boxes**: For any industry-specific term, provide a clear definition. Format: "**[Term]** is [concise definition]." AIO frequently cites definitions.
-7. **Statistics with Sources**: Include specific numbers with attribution. "According to [Source], [statistic]." AIO prefers citeable, specific claims over vague assertions.
-8. **Publication Date**: Include a visible publication date and last-updated date. AIO deprioritizes undated content for time-sensitive queries.
-9. **Author Byline**: Display author name with credentials. Link to an author page with bio, credentials, and sameAs links.
-10. **Page Depth**: Keep target pages within 3 clicks of homepage. AIO rarely cites deep, orphaned content.
-
-### Scoring Rubric (0-100)
-
-| Criterion | Points | How to Score |
-|---|---|---|
-| Ranks in top 10 for target queries | 20 | 20 if yes, 10 if top 20, 0 if beyond |
-| Question-based headings present | 10 | 2 points per question heading, max 10 |
-| Direct answers after headings | 15 | 3 points per direct answer, max 15 |
-| Tables present for comparison data | 10 | 10 if tables used appropriately, 5 if partial, 0 if absent |
-| Lists for processes/features | 10 | 10 if present, 5 if partial |
-| FAQ section with 5+ questions | 10 | 10 if 5+, 5 if 1-4, 0 if none |
-| Statistics with citations | 10 | 2 points per cited stat, max 10 |
-| Publication/updated date visible | 5 | 5 if both dates, 3 if one, 0 if none |
-| Author byline with credentials | 5 | 5 if full byline, 3 if name only, 0 if none |
-| Clean URL + heading hierarchy | 5 | 5 if H1>H2>H3 clean, 3 if minor issues, 0 if broken |
+**Current behaviour:** Returns estimated scores based on available worker inputs.
+Platform-specific checklists below are reference methodology for the full implementation.
 
 ---
 
-## Platform 2: ChatGPT Web Search
+## Platform Priorities Reference
 
-### How ChatGPT Selects Sources
-- Uses **Bing's search index** as its foundation (not Google)
-- Top citation sources by domain share: **Wikipedia (47.9%)**, Reddit (11.3%), YouTube, major news outlets
-- ChatGPT heavily weights **entity recognition** — if your brand exists as a structured entity (Wikipedia, Wikidata, Crunchbase), it is far more likely to be cited
-- Prefers **authoritative, well-established sources** over new or niche sites
-- Longer, more comprehensive articles get cited more often than short pieces
-- ChatGPT tends to cite **the most canonical source** for a claim rather than the original
-
-### Optimization Checklist
-
-1. **Wikipedia Presence**: Check if the brand/person/product has a Wikipedia article. If not, assess notability criteria. If notable, create a draft. If an article exists, ensure it is accurate and current.
-2. **Wikidata Entity**: Verify the entity exists on Wikidata (wikidata.org). If not, create a Wikidata item with key properties: instance of, official website, social media links, founding date, headquarters location.
-3. **Bing Webmaster Tools**: Verify the site is registered in Bing Webmaster Tools. Submit sitemap. Check for crawl errors.
-4. **Bing Index Coverage**: Use `site:domain.com` on Bing to verify key pages are indexed. Bing may have different indexed pages than Google.
-5. **Reddit Authority**: Check for brand mentions on Reddit. Identify relevant subreddits. Assess whether the brand participates authentically in discussions.
-6. **YouTube Presence**: Verify YouTube channel exists with relevant content. Video descriptions should contain full URLs and entity information.
-7. **Authoritative Backlinks**: ChatGPT/Bing weight .edu, .gov, and major publication backlinks heavily. Audit backlink profile for these sources.
-8. **Entity Consistency**: Brand name, founding date, leadership, and key facts must be consistent across Wikipedia, Crunchbase, LinkedIn, and the official website.
-9. **Comprehensive Content**: Pages targeting ChatGPT citation should be **2000+ words** with thorough topic coverage. ChatGPT prefers single authoritative sources over combining multiple thin pages.
-10. **Clear Attribution**: Include "About" sections, company descriptions, and founding stories. ChatGPT uses these for entity grounding.
-
-### Scoring Rubric (0-100)
-
-| Criterion | Points | How to Score |
-|---|---|---|
-| Wikipedia article exists and is accurate | 20 | 20 if exists, 10 if stub, 0 if none |
-| Wikidata entity with 5+ properties | 10 | 10 if complete, 5 if basic, 0 if none |
-| Bing index coverage of key pages | 10 | 10 if full, 5 if partial, 0 if poor |
-| Reddit brand mentions (positive) | 10 | 10 if active discussions, 5 if mentions, 0 if none |
-| YouTube channel with relevant content | 10 | 10 if active, 5 if present but sparse, 0 if none |
-| Authoritative backlinks (.edu, .gov, press) | 15 | 3 points per authoritative backlink category, max 15 |
-| Entity consistency across platforms | 10 | 10 if consistent, 5 if minor discrepancies, 0 if major |
-| Content comprehensiveness (2000+ words) | 10 | 10 if thorough, 5 if adequate, 0 if thin |
-| Bing Webmaster Tools configured | 5 | 5 if verified, 0 if not |
+| Platform | #1 Signal | #2 Signal | #3 Signal |
+|---|---|---|---|
+| Google AI Overviews | Top-10 organic rank + Q&A structure | Tables/lists | Featured snippet readiness |
+| ChatGPT Web Search | Wikipedia entity | Bing index coverage | Reddit mentions |
+| Perplexity AI | Reddit presence | Original research | Content freshness |
+| Google Gemini | YouTube content | Knowledge Panel | Schema.org |
+| Bing Copilot | IndexNow | Bing WMT | LinkedIn |
 
 ---
 
-## Platform 3: Perplexity AI
+## Input Contract (locked in issue #2)
 
-### How Perplexity Selects Sources
-- Top citation sources: **Reddit (46.7%)**, Wikipedia, YouTube, major publications
-- Perplexity places the **heaviest emphasis on community validation** of all AI search platforms
-- Strongly favors **discussion threads** where claims are debated, validated, or expanded by multiple participants
-- Prefers recent content — publication date is a strong ranking signal
-- Cites **multiple sources per answer** (typically 5-15), so there is more opportunity for mid-authority sites to appear
-- Uses its own crawling infrastructure in addition to search APIs
+This worker receives the outputs of the other 7 workers:
 
-### Optimization Checklist
+```json
+{
+  "citability": { "score": 72, "critical_3": [...], "quick_wins_3": [...] },
+  "content": { "score": 55, ... },
+  "technical": { "score": 68, ... },
+  "crawlers": { "score": 80, ... },
+  "schema": { "score": 45, ... },
+  "llmstxt": { "score": 0, ... },
+  "brand_mentions": { "score": 38, ... }
+}
+```
 
-1. **Active Reddit Presence**: The brand or its representatives should participate authentically in relevant subreddit discussions. Not promotional — helpful, specific, and community-oriented.
-2. **Reddit AMAs and Threads**: Encourage or participate in AMAs, detailed discussion threads, and community Q&As. Perplexity treats these as high-signal content.
-3. **Forum and Community Presence**: Beyond Reddit, check Hacker News, Stack Overflow, Quora, and niche industry forums. Perplexity indexes these heavily.
-4. **Discussion-Friendly Content**: Publish content that invites discussion — opinion pieces, research findings, contrarian takes, original data. Content that gets shared and debated in communities ranks higher.
-5. **Freshness Signals**: Publish content with clear dates. Update content regularly. Perplexity deprioritizes stale content more aggressively than other platforms.
-6. **Multiple Source Validation**: Claims in your content should be supported by other sources. Perplexity cross-references and prefers claims it can verify from multiple origins.
-7. **YouTube Video Content**: Create video content that Perplexity can reference. Ensure video titles, descriptions, and transcripts contain target information.
-8. **Direct, Quotable Passages**: Write paragraphs that can stand alone as citations. Each paragraph should make one clear point with supporting evidence.
-9. **Original Data and Research**: Publish original surveys, benchmarks, case studies, or datasets. Perplexity heavily favors primary sources.
-10. **Perplexity Pages**: Check if Perplexity has created a "Page" about your topic/brand. These are curated summaries that influence future citations.
-
-### Scoring Rubric (0-100)
-
-| Criterion | Points | How to Score |
-|---|---|---|
-| Active Reddit presence in relevant subreddits | 20 | 20 if active contributor, 10 if mentioned, 0 if absent |
-| Forum/community mentions (HN, SO, Quora) | 10 | 10 if multiple platforms, 5 if one, 0 if none |
-| Content freshness (updated within 6 months) | 10 | 10 if recent, 5 if within year, 0 if older |
-| Original research/data published | 15 | 15 if original research, 10 if case studies, 5 if some data, 0 if none |
-| YouTube content with transcripts | 10 | 10 if active channel, 5 if some videos, 0 if none |
-| Quotable, standalone paragraphs | 10 | 2 points per well-structured quotable paragraph, max 10 |
-| Multi-source claim validation | 10 | 10 if claims well-sourced, 5 if some sourcing, 0 if none |
-| Discussion-generating content | 10 | 10 if content gets shared/discussed, 5 if some engagement, 0 if none |
-| Wikipedia/Wikidata presence | 5 | 5 if present, 0 if absent |
+Platform scores are derived from these inputs — no additional HTTP requests.
 
 ---
 
-## Platform 4: Google Gemini
+## Worker Return Format
 
-### How Gemini Selects Sources
-- Uses **Google's search index** plus strong weighting toward **Google-owned properties**
-- YouTube content is weighted significantly more heavily than in standard Google Search
-- Google Business Profile data is directly accessible to Gemini
-- Gemini uses Google's Knowledge Graph directly — entity presence in Knowledge Graph is a major advantage
-- Structured data (Schema.org) is consumed directly by Gemini for entity understanding
-- Gemini multi-modal: can reference images, videos, and text together
-
-### Optimization Checklist
-
-1. **Google Knowledge Panel**: Check if the brand has a Google Knowledge Panel. If not, claim it through Google Business Profile or structured data. Ensure all information is accurate.
-2. **Google Business Profile**: Complete and optimize GBP with all fields: hours, services, photos, posts, Q&A. Gemini pulls directly from GBP for local queries.
-3. **YouTube Strategy**: Create YouTube content for every key topic. Optimize titles, descriptions, timestamps, and closed captions. Gemini cites YouTube more than any other AI platform.
-4. **YouTube Chapters and Timestamps**: Use chapters (timestamps in description) so Gemini can reference specific segments of videos.
-5. **Google Merchant Center**: For e-commerce, ensure products are in Google Merchant Center. Gemini references product data directly.
-6. **Structured Data (Schema.org)**: Implement comprehensive Schema.org markup. Gemini uses this for entity understanding more aggressively than other platforms.
-7. **Google Sites Ecosystem**: Ensure presence across Google ecosystem: Google Scholar (for research), Google News (for publishers), Google Maps (for local).
-8. **Image Optimization**: Gemini is multi-modal. Use descriptive alt text, structured image filenames, and high-quality images. Include relevant images with every piece of content.
-9. **Google E-E-A-T Signals**: All standard Google E-E-A-T signals apply with extra weight. Author pages, about pages, editorial policies, and expertise demonstrations.
-10. **Chrome Web Store / Google Workspace Marketplace**: For software companies, presence on Google platforms adds entity signals.
-
-### Scoring Rubric (0-100)
-
-| Criterion | Points | How to Score |
-|---|---|---|
-| Google Knowledge Panel exists | 15 | 15 if complete, 10 if partial, 0 if none |
-| Google Business Profile complete | 10 | 10 if fully optimized, 5 if basic, 0 if none |
-| YouTube channel with topic-relevant content | 20 | 20 if active with chapters, 10 if present, 0 if none |
-| Schema.org structured data implemented | 15 | 15 if comprehensive, 10 if basic, 5 if minimal, 0 if none |
-| Google ecosystem presence (Scholar, News, Maps) | 10 | 10 if 3+, 5 if 1-2, 0 if none |
-| Image optimization (alt text, filenames) | 10 | 10 if all images optimized, 5 if partial, 0 if none |
-| E-E-A-T signals (author pages, about, editorial) | 10 | 10 if strong, 5 if partial, 0 if weak |
-| Google Merchant Center (if e-commerce) | 5 | 5 if applicable and active, N/A otherwise |
-| Multi-modal content (text + images + video) | 5 | 5 if rich multi-modal, 3 if some, 0 if text-only |
-
----
-
-## Platform 5: Bing Copilot
-
-### How Copilot Selects Sources
-- Uses **Bing's search index** (shared infrastructure with ChatGPT but different ranking/selection)
-- Supports **IndexNow protocol** for near-instant indexing of new and updated content
-- Copilot tends to cite **fewer sources per answer** (typically 3-5) but gives more prominent attribution
-- Microsoft ecosystem integration: LinkedIn, GitHub, Microsoft Learn content is weighted
-- Copilot prefers pages with clear, structured markup and fast load times
-
-### Optimization Checklist
-
-1. **Bing Webmaster Tools**: Register and verify site. Submit XML sitemap. Review and fix any crawl issues.
-2. **IndexNow Implementation**: Implement the IndexNow protocol to notify Bing of content changes in real-time. Submit a key file at `/.well-known/indexnow-key.txt` and ping the IndexNow API on content publish/update.
-3. **LinkedIn Company Page**: Ensure the company LinkedIn page is complete with accurate description, employee connections, and regular posts. Copilot indexes LinkedIn content.
-4. **GitHub Presence**: For tech companies, maintain an active GitHub presence. Copilot references GitHub repos, documentation, and README files.
-5. **Microsoft Learn / Documentation**: If relevant, contribute to Microsoft Learn or ensure documentation is compatible with Microsoft's documentation standards.
-6. **Bing Places for Business**: Equivalent to Google Business Profile. Complete all fields for local search visibility in Copilot.
-7. **Clear Meta Descriptions**: Bing/Copilot weights meta descriptions more heavily than Google does. Write compelling, keyword-rich meta descriptions for every page.
-8. **Social Signals**: Bing has historically weighted social signals (shares, likes, engagement) more than Google. Maintain active social media presence.
-9. **Exact-Match Keywords**: Bing's algorithm is more literal about keyword matching than Google. Include exact target phrases in titles, headings, and body content.
-10. **Fast Page Load**: Copilot deprioritizes slow pages. Target sub-2-second load time. Optimize images, enable compression, minimize render-blocking resources.
-
-### Scoring Rubric (0-100)
-
-| Criterion | Points | How to Score |
-|---|---|---|
-| Bing Webmaster Tools verified + sitemap | 15 | 15 if verified, 5 if partial, 0 if not |
-| IndexNow protocol implemented | 15 | 15 if active, 0 if not |
-| Bing index coverage of key pages | 10 | 10 if full, 5 if partial, 0 if poor |
-| LinkedIn company page (complete) | 10 | 10 if complete, 5 if basic, 0 if none |
-| GitHub presence (if applicable) | 5 | 5 if active, N/A if not applicable |
-| Meta descriptions optimized | 10 | 10 if all key pages, 5 if partial, 0 if missing |
-| Social media engagement signals | 10 | 10 if active engagement, 5 if present, 0 if none |
-| Exact-match keywords in titles/headings | 10 | 10 if well-optimized, 5 if partial, 0 if not |
-| Page load speed < 2 seconds | 10 | 10 if < 2s, 5 if < 4s, 0 if > 4s |
-| Bing Places configured (if local) | 5 | 5 if complete, N/A if not local |
-
----
-
-## Cross-Platform Summary
-
-### Universal Optimization Actions (help ALL platforms)
-1. Wikipedia/Wikidata entity presence
-2. YouTube channel with relevant content
-3. Comprehensive, well-structured content with clear headings
-4. Schema.org structured data (especially Organization + sameAs)
-5. Fast page load and clean HTML
-6. Author pages with credentials and sameAs links
-7. Regular content updates with visible dates
-
-### Platform-Specific Priorities
-| Priority | Google AIO | ChatGPT | Perplexity | Gemini | Copilot |
-|---|---|---|---|---|---|
-| #1 | Top-10 ranking | Wikipedia | Reddit presence | YouTube | IndexNow |
-| #2 | Q&A structure | Entity graph | Original research | Knowledge Panel | Bing WMT |
-| #3 | Tables/lists | Bing SEO | Freshness | Schema.org | LinkedIn |
-| #4 | Featured snippets | Reddit | Community forums | GBP | Meta descriptions |
-
----
-
-## Output Format
-
-Generate **GEO-PLATFORM-OPTIMIZATION.md** with the following structure:
-
-```markdown
-# GEO Platform Optimization Report — [Domain]
-Date: [Date]
-
-## Overall Platform Readiness
-- Combined GEO Score: XX/100 (average of all platform scores)
-
-## Platform Scores
-| Platform | Score | Status |
-|---|---|---|
-| Google AI Overviews | XX/100 | [Strong/Moderate/Weak] |
-| ChatGPT Web Search | XX/100 | [Strong/Moderate/Weak] |
-| Perplexity AI | XX/100 | [Strong/Moderate/Weak] |
-| Google Gemini | XX/100 | [Strong/Moderate/Weak] |
-| Bing Copilot | XX/100 | [Strong/Moderate/Weak] |
-
-Status thresholds: Strong = 70+, Moderate = 40-69, Weak = 0-39
-
-## Platform Details
-[Per-platform breakdown with score, gaps found, specific actions]
-
-## Prioritized Action Plan
-### Quick Wins (this week)
-[Actions that improve multiple platform scores with minimal effort]
-
-### Medium-Term (this month)
-[Actions requiring content creation or technical changes]
-
-### Strategic (this quarter)
-[Actions requiring entity building, community development, or platform presence]
+```json
+{
+  "score": 42,
+  "critical_3": [
+    "ChatGPT: No Wikipedia/Wikidata entity — brand not in ChatGPT knowledge graph",
+    "Perplexity: No Reddit presence — top citation source for Perplexity missing",
+    "Gemini: No YouTube channel — Gemini's primary differentiated citation source absent"
+  ],
+  "quick_wins_3": [
+    "Create Wikidata entity to unlock ChatGPT entity recognition",
+    "Engage authentically in 2-3 relevant subreddits for Perplexity visibility",
+    "Launch YouTube channel with topic explainers for Gemini citation eligibility"
+  ]
+}
 ```

--- a/skills/geo-schema/SKILL.md
+++ b/skills/geo-schema/SKILL.md
@@ -1,370 +1,162 @@
 ---
 name: geo-schema
-description: Schema.org structured data audit and generation optimized for AI discoverability — detect, validate, and generate JSON-LD markup
-version: 1.0.0
-author: geo-seo-claude
-tags: [geo, schema, structured-data, json-ld, entity-recognition, ai-discoverability]
-allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+description: >
+  JSON-LD structured data detection, validation, and generation. Checks for schema
+  completeness, sameAs coverage, and GEO-critical markup. Generated JSON-LD is emitted
+  as inline code blocks — not written to disk. Invoked directly via /geo schema or as
+  a parallel worker in /geo audit.
 ---
 
 # GEO Schema & Structured Data
 
 ## Purpose
 
-Structured data is the primary machine-readable signal that tells AI systems what an entity IS, what it does, and how it connects to other entities. While schema markup has traditionally been about earning Google rich results, its role in GEO is fundamentally different: **structured data is how AI models understand and trust your entity**. A complete entity graph in structured data dramatically increases citation probability across all AI search platforms.
+Structured data is how AI models understand what an entity IS and how it connects to
+other entities. Strong `sameAs` links and a complete `Organization` schema are the
+fastest path to entity recognition across all AI platforms.
 
-## How to Use This Skill
-
-1. Fetch the target page HTML using `fetch_page.py` (see note below)
-2. Detect all existing structured data (JSON-LD, Microdata, RDFa)
-3. Validate detected schemas against Schema.org specifications
-4. Identify missing recommended schemas based on business type
-5. Generate ready-to-use JSON-LD code blocks
-6. Output GEO-SCHEMA-REPORT.md
+**This worker's domain:** JSON-LD detection, validation, and generation.
+Platform-specific interpretation of schema scores is handled by `geo-platform-optimizer`.
 
 ---
 
-## Step 1: Detection
+## Detection
 
-**IMPORTANT:** WebFetch converts HTML to markdown and strips `<head>` content, which removes JSON-LD blocks. Use `fetch_page.py` instead:
-```bash
-python3 ~/.claude/skills/geo/scripts/fetch_page.py <url> page
-```
-The output includes a `structured_data` array with all parsed JSON-LD blocks from the page.
+Parse `<script type="application/ld+json">` blocks from page HTML (server-rendered only
+— JS-injected schema has delayed processing per Google Dec 2025 guidance, flag this).
 
-### Scan for JSON-LD
-Look for `<script type="application/ld+json">` blocks in the HTML. Parse each block as JSON. A page may contain multiple JSON-LD blocks — collect all of them.
-
-### Scan for Microdata
-Look for elements with `itemscope`, `itemtype`, and `itemprop` attributes. Map the hierarchy of nested items. Note: Microdata is harder for AI crawlers to parse than JSON-LD. Flag a recommendation to migrate to JSON-LD if Microdata is the only format found.
-
-### Scan for RDFa
-Look for elements with `typeof`, `property`, and `vocab` attributes. Similar to Microdata — recommend migration to JSON-LD.
-
-### Priority Order
-JSON-LD is the **strongly recommended format** for GEO. Google, Bing, and AI platforms all process JSON-LD most reliably. If the site uses Microdata or RDFa exclusively, flag this as a high-priority migration.
+Also check for Microdata and RDFa — recommend migration to JSON-LD if found exclusively.
 
 ---
 
-## Step 2: Validation
+## GEO-Critical Schema Types
 
-For each detected schema block, validate:
+### Organization (every business site — CRITICAL)
 
-1. **Valid JSON**: Is the JSON-LD syntactically valid? Check for trailing commas, unquoted keys, malformed strings.
-2. **Valid @type**: Does the `@type` match a recognized Schema.org type? Check against https://schema.org/docs/full.html.
-3. **Required Properties**: Does the schema include all required properties for its type? (See per-type requirements below.)
-4. **Recommended Properties**: Does the schema include recommended properties that increase AI discoverability?
-5. **sameAs Links**: Does the schema include `sameAs` properties linking to other platform presences?
-6. **URL Validity**: Do all URLs in the schema resolve (not 404)?
-7. **Nesting**: Is the schema properly nested (e.g., author inside Article, address inside Organization)?
-8. **Rendering Method**: Is the JSON-LD in the server-rendered HTML or injected via JavaScript? Per Google's December 2025 guidance, **JavaScript-injected structured data may face delayed processing**. Flag any schema that requires JS execution.
-
----
-
-## Step 3: Schema Types for GEO
-
-### Organization (CRITICAL — every business site)
-Essential for entity recognition across all AI platforms. This is how AI models identify WHAT the business is.
-
-**Required properties:**
-- `@type`: "Organization" (or subtype: Corporation, LocalBusiness, etc.)
-- `name`: Official business name
-- `url`: Official website URL
-- `logo`: URL to logo image (ImageObject preferred)
-
-**Recommended properties for GEO:**
-- `sameAs`: Array of ALL platform URLs (see sameAs strategy below)
-- `description`: 1-2 sentence description of the organization
-- `foundingDate`: ISO 8601 date
-- `founder`: Person schema
-- `address`: PostalAddress schema
-- `contactPoint`: ContactPoint with telephone, email, contactType
-- `areaServed`: Geographic area
-- `numberOfEmployees`: QuantitativeValue
-- `industry`: Text or DefinedTerm
-- `award`: Array of awards received
-- `knowsAbout`: Array of topics the organization is expert in (strong GEO signal)
-
-### LocalBusiness (for businesses with physical locations)
-Extends Organization. Critical for local AI search results and Google Gemini.
-
-**Additional required properties:**
-- `address`: Full PostalAddress
-- `telephone`: Phone number
-- `openingHoursSpecification`: Operating hours
+**Required:** `@type`, `name`, `url`, `logo`
 
 **Recommended for GEO:**
-- `geo`: GeoCoordinates (latitude, longitude)
-- `priceRange`: Price indicator
-- `aggregateRating`: AggregateRating schema
-- `review`: Array of Review schemas
-- `hasMap`: URL to Google Maps
+- `sameAs` — array of all platform URLs (see sameAs strategy below)
+- `description` — 1–2 sentences
+- `foundingDate` — ISO 8601
+- `founder` — Person schema
+- `knowsAbout` — array of expertise topics (strong GEO signal)
+- `contactPoint`
 
-### Article + Author (CRITICAL for publishers)
-The Author schema is one of the strongest E-E-A-T signals for AI platforms.
+### Article + Author (publishers — CRITICAL)
 
-**Article required:**
-- `@type`: "Article" (or NewsArticle, BlogPosting, TechArticle)
-- `headline`: Article title
-- `datePublished`: ISO 8601
-- `dateModified`: ISO 8601 (critical for freshness signals)
-- `author`: Person or Organization schema
-- `publisher`: Organization schema with logo
-- `image`: Representative image
+Article: `headline`, `datePublished`, `dateModified`, `author`, `publisher`, `image`
 
-**Author (Person) required for GEO:**
-- `name`: Full name
-- `url`: Author page URL on the site
-- `sameAs`: LinkedIn, Twitter, personal site, Google Scholar, ORCID
-- `jobTitle`: Professional title
-- `worksFor`: Organization schema
-- `knowsAbout`: Array of expertise areas
-- `alumniOf`: Educational institutions
-- `award`: Professional awards
+Author (Person) for GEO:
+- `name`, `url`, `sameAs` (LinkedIn, personal site, Google Scholar)
+- `jobTitle`, `worksFor`, `knowsAbout`, `alumniOf`
 
-### Product (for e-commerce)
-**Required:**
-- `name`, `description`, `image`
-- `offers`: Offer with price, priceCurrency, availability
-- `brand`: Brand schema
-- `sku` or `gtin`/`mpn`
+### Business-type specific
 
-**Recommended for GEO:**
-- `aggregateRating`: AggregateRating
-- `review`: Array of individual reviews
-- `category`: Product category
-- `material`, `weight`, `width`, `height` (where applicable)
+| Type | Schema |
+|---|---|
+| SaaS | `SoftwareApplication` with `featureList`, `aggregateRating` |
+| Local | `LocalBusiness` with `address`, `geo`, `openingHoursSpecification` |
+| E-commerce | `Product` with `offers`, `aggregateRating`, `brand` |
+| Publisher | `Article`/`NewsArticle` + `Person` (author) + `WebSite` |
 
 ### FAQPage
-**Status as of 2024**: Google restricts FAQ rich results to government and health sites. However, the FAQPage schema still serves GEO purposes — AI platforms parse FAQ structured data for question-answer extraction. Implement it for AI readability even though rich results may not appear.
 
-**Structure:**
-- `@type`: "FAQPage"
-- `mainEntity`: Array of Question schemas, each with `acceptedAnswer` containing an Answer schema
+Google restricted FAQPage rich results to health/govt since Aug 2023. Still implement
+it — AI platforms parse FAQPage schema for Q&A extraction.
 
-### SoftwareApplication (for SaaS)
-**Required:**
-- `name`, `description`
-- `applicationCategory`: e.g., "BusinessApplication"
-- `operatingSystem`: Supported platforms
-- `offers`: Pricing
+### WebSite + SearchAction (always on homepage)
 
-**Recommended for GEO:**
-- `aggregateRating`: User ratings
-- `featureList`: Array of features (strong citation signal)
-- `screenshot`: Screenshots
-- `softwareVersion`: Current version
-- `releaseNotes`: Link to changelog
-
-### WebSite + SearchAction (for sitelinks search box)
-**Structure:**
 ```json
 {
   "@type": "WebSite",
-  "name": "Site Name",
   "url": "https://example.com",
   "potentialAction": {
     "@type": "SearchAction",
-    "target": {
-      "@type": "EntryPoint",
-      "urlTemplate": "https://example.com/search?q={search_term_string}"
-    },
+    "target": {"@type": "EntryPoint", "urlTemplate": "https://example.com/search?q={search_term_string}"},
     "query-input": "required name=search_term_string"
   }
 }
 ```
 
-### Person (standalone — for personal brands, authors, thought leaders)
-Use as a standalone schema on About/Bio pages. This builds the entity graph for individual expertise.
-
-**Required:** `name`, `url`
-**Recommended for GEO:** `sameAs`, `jobTitle`, `worksFor`, `knowsAbout`, `alumniOf`, `award`, `description`, `image`
-
-### speakable Property (for voice/AI assistants)
-The `speakable` property marks specific sections of content as particularly suitable for voice and AI assistant consumption. Add to Article or WebPage schemas.
+### speakable (articles)
 
 ```json
-{
-  "@type": "Article",
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "cssSelector": [".article-summary", ".key-takeaway"]
-  }
+"speakable": {
+  "@type": "SpeakableSpecification",
+  "cssSelector": [".article-summary", ".key-takeaway"]
 }
 ```
-This signals to AI assistants which passages are the best candidates for citation or reading aloud.
+
+Marks content as suitable for AI assistant voice citation.
 
 ---
 
-## Step 4: Deprecated/Changed Schemas to Flag
+## sameAs Strategy (CRITICAL for entity recognition)
 
-| Schema | Status | Note |
-|---|---|---|
-| HowTo | Rich results deprecated Aug 2023 | Still useful for AI parsing, but do not promise rich results |
-| FAQPage | Restricted to govt/health Aug 2023 | Still useful for AI parsing (see above) |
-| SpecialAnnouncement | Deprecated 2023 | Was for COVID; remove if still present |
-| CourseInfo | Replaced by Course updates 2024 | Use updated Course schema properties |
-| VideoObject `contentUrl` | Changed behavior 2024 | Must point to actual video file, not page URL |
-| Review snippet | Stricter enforcement 2024 | Self-serving reviews on product pages may not display |
+Priority order:
+1. Wikipedia article
+2. Wikidata item (`https://www.wikidata.org/wiki/Q...`)
+3. LinkedIn company/personal page
+4. YouTube channel
+5. Twitter/X
+6. Crunchbase (tech/startups)
+7. GitHub (developer brands)
+8. Google Scholar / ORCID (researchers)
+9. Industry-specific directories
 
-Flag any deprecated schemas found and recommend replacements.
-
----
-
-## Step 5: sameAs Strategy (CRITICAL for Entity Recognition)
-
-The `sameAs` property is the single most important structured data property for GEO. It tells AI systems: "This entity on my website is the SAME entity as these profiles elsewhere." This creates the entity graph that AI platforms use to verify, trust, and cite sources.
-
-### Recommended sameAs Links (in priority order)
-
-1. **Wikipedia article** — highest authority entity link
-2. **Wikidata item** — machine-readable entity identifier (e.g., `https://www.wikidata.org/wiki/Q12345`)
-3. **LinkedIn** — company page or personal profile
-4. **YouTube** — channel URL
-5. **Twitter/X** — profile URL
-6. **Facebook** — page URL
-7. **Crunchbase** — company profile (for startups/tech)
-8. **GitHub** — organization or personal profile (for tech)
-9. **Google Scholar** — author profile (for researchers/academics)
-10. **ORCID** — researcher identifier (for academics)
-11. **Instagram** — profile URL
-12. **Apple App Store / Google Play** — app listings (for software)
-13. **BBB** — Better Business Bureau listing (for US businesses)
-14. **Industry directories** — relevant vertical directories
-
-### sameAs Audit Process
-1. Collect all known web presences for the entity
-2. Check that each URL resolves (not 404 or redirected)
-3. Verify the Organization/Person schema includes ALL of them
-4. Check that the information on each platform is consistent (name, description, founding date, etc.)
-5. Flag any platforms where the entity should have a presence but does not
+Verify each URL resolves (200) before including. Audit for inconsistent entity data
+(name, founding date, leadership) across platforms.
 
 ---
 
-## Step 6: JSON-LD Generation
+## Deprecated Schemas to Flag
 
-Based on the detected business type, generate ready-to-paste JSON-LD blocks. Always generate:
+| Schema | Status |
+|---|---|
+| HowTo rich results | Deprecated Aug 2023 — content still useful for AI parsing |
+| SpecialAnnouncement | Deprecated 2023 (COVID) — remove if present |
+| VideoObject `contentUrl` | Must point to video file, not page URL (2024) |
 
-1. **Organization or Person** (depending on entity type) — always
-2. **WebSite with SearchAction** — always for the homepage
-3. **Business-type-specific** — Article for publishers, Product for e-commerce, LocalBusiness for local, SoftwareApplication for SaaS
-4. **BreadcrumbList** — for any page deeper than homepage
+---
 
-### Generation Rules
-- Use the `@graph` pattern to include multiple schemas in one JSON-LD block
-- All URLs must be absolute (not relative)
-- Include `@id` properties for cross-referencing between schemas
-- Use ISO 8601 for all dates
-- Include `speakable` on Article schemas with CSS selectors pointing to key content sections
-- Place JSON-LD in `<head>` section — NOT injected via JavaScript
+## Scoring (0–100)
 
-### Template: Organization with Full GEO Signals
+| Criterion | Points |
+|---|---|
+| Organization/Person schema present and complete | 15 |
+| sameAs links (5+ valid platforms) | 15 (3 pts each, max 15) |
+| Article schema with full author details | 10 |
+| Business-type-specific schema | 10 |
+| WebSite + SearchAction | 5 |
+| BreadcrumbList on inner pages | 5 |
+| JSON-LD format (not Microdata/RDFa) | 5 |
+| Server-rendered (not JS-injected) | 10 |
+| speakable on articles | 5 |
+| Valid JSON + valid Schema.org types | 10 |
+| knowsAbout on Organization/Person | 5 |
+| No deprecated schemas | 5 |
+
+---
+
+## Worker Return Format
+
 ```json
 {
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  "@id": "https://example.com/#organization",
-  "name": "Company Name",
-  "url": "https://example.com",
-  "logo": {
-    "@type": "ImageObject",
-    "url": "https://example.com/logo.png",
-    "width": 600,
-    "height": 60
-  },
-  "description": "Concise description of what the company does.",
-  "foundingDate": "2020-01-15",
-  "founder": {
-    "@type": "Person",
-    "name": "Founder Name",
-    "sameAs": "https://www.linkedin.com/in/founder"
-  },
-  "address": {
-    "@type": "PostalAddress",
-    "streetAddress": "123 Main St",
-    "addressLocality": "City",
-    "addressRegion": "State",
-    "postalCode": "12345",
-    "addressCountry": "US"
-  },
-  "contactPoint": {
-    "@type": "ContactPoint",
-    "telephone": "+1-555-555-5555",
-    "contactType": "customer service",
-    "email": "support@example.com"
-  },
-  "sameAs": [
-    "https://en.wikipedia.org/wiki/Company_Name",
-    "https://www.wikidata.org/wiki/Q12345",
-    "https://www.linkedin.com/company/company-name",
-    "https://www.youtube.com/@companyname",
-    "https://twitter.com/companyname",
-    "https://github.com/companyname",
-    "https://www.crunchbase.com/organization/company-name"
+  "score": 45,
+  "critical_3": [
+    "No Organization schema on homepage — AI systems cannot identify the entity",
+    "No sameAs links — entity not connected to any external platform",
+    "Article pages missing dateModified — AI systems treat content as stale"
   ],
-  "knowsAbout": [
-    "Topic 1",
-    "Topic 2",
-    "Topic 3"
+  "quick_wins_3": [
+    "Add Organization JSON-LD with sameAs linking to LinkedIn, YouTube, and Wikipedia",
+    "Add dateModified to all Article schemas",
+    "Add speakable CSS selectors to article schema pointing to intro paragraph"
   ]
 }
 ```
 
----
-
-## Scoring Rubric (0-100)
-
-| Criterion | Points | How to Score |
-|---|---|---|
-| Organization/Person schema present and complete | 15 | 15 if full, 10 if basic, 0 if none |
-| sameAs links (5+ platforms) | 15 | 3 per valid sameAs link, max 15 |
-| Article schema with author details | 10 | 10 if full author schema, 5 if name only, 0 if none |
-| Business-type-specific schema present | 10 | 10 if complete, 5 if partial, 0 if missing |
-| WebSite + SearchAction | 5 | 5 if present, 0 if not |
-| BreadcrumbList on inner pages | 5 | 5 if present, 0 if not |
-| JSON-LD format (not Microdata/RDFa) | 5 | 5 if JSON-LD, 3 if mixed, 0 if only Microdata/RDFa |
-| Server-rendered (not JS-injected) | 10 | 10 if in HTML source, 5 if JS but in head, 0 if dynamic JS |
-| speakable property on articles | 5 | 5 if present, 0 if not |
-| Valid JSON + valid Schema.org types | 10 | 10 if no errors, 5 if minor issues, 0 if major errors |
-| knowsAbout property on Organization/Person | 5 | 5 if present with 3+ topics, 0 if missing |
-| No deprecated schemas present | 5 | 5 if clean, 0 if deprecated schemas found |
-
----
-
-## Output Format
-
-Generate **GEO-SCHEMA-REPORT.md** with:
-
-```markdown
-# GEO Schema & Structured Data Report — [Domain]
-Date: [Date]
-
-## Schema Score: XX/100
-
-## Detected Schemas
-| Page | Schema Type | Format | Status | Issues |
-|---|---|---|---|---|
-| / | Organization | JSON-LD | Valid | Missing sameAs |
-| /blog/post-1 | Article | JSON-LD | Valid | No author schema |
-
-## Validation Results
-[List each schema with pass/fail per property]
-
-## Missing Recommended Schemas
-[List schemas that should be present based on business type but are not]
-
-## sameAs Audit
-| Platform | URL | Status |
-|---|---|---|
-| Wikipedia | [URL or "Not found"] | Present/Missing |
-| LinkedIn | [URL or "Not found"] | Present/Missing |
-[Continue for all recommended platforms]
-
-## Generated JSON-LD Code
-[Ready-to-paste JSON-LD blocks for each missing or incomplete schema]
-
-## Implementation Notes
-- Where to place each JSON-LD block
-- Server-rendering requirements
-- Testing with Google Rich Results Test and Schema.org Validator
-```
+When generating JSON-LD, emit as fenced code block with `json` syntax highlighting.
+Use `@graph` pattern to combine multiple schemas in one block. All URLs absolute.
+Place in `<head>` — never JS-injected.

--- a/skills/geo-technical/SKILL.md
+++ b/skills/geo-technical/SKILL.md
@@ -1,448 +1,155 @@
 ---
 name: geo-technical
-description: Technical SEO audit with GEO-specific checks — crawlability, indexability, security, performance, SSR, and AI crawler access
-version: 1.0.0
-author: geo-seo-claude
-tags: [geo, technical-seo, core-web-vitals, ssr, crawlability, security, performance]
-allowed-tools: Read, Grep, Glob, Bash, WebFetch, Write
+description: >
+  Technical SEO audit with GEO-specific checks. Covers crawlability, indexability,
+  security, URL structure, mobile, Core Web Vitals, server-side rendering (critical for
+  AI crawlers), and page performance. Invoked directly via /geo technical or as a
+  parallel worker in /geo audit.
 ---
 
-# GEO Technical SEO Audit
+# GEO Technical SEO Auditor
 
 ## Purpose
 
-Technical SEO forms the foundation of both traditional search visibility and AI search citation. A technically broken site cannot be crawled, indexed, or cited by any platform. This skill audits 8 categories of technical health with specific attention to GEO requirements — most critically, **server-side rendering** (AI crawlers do not execute JavaScript) and **AI crawler access** (many sites inadvertently block AI crawlers in robots.txt).
+Technical health is the foundation of AI visibility. AI crawlers do not execute JavaScript.
+A client-side-rendered site is invisible to every AI crawler regardless of content quality.
 
-## How to Use This Skill
-
-1. Collect the target URL (homepage + 2-3 key inner pages)
-2. Fetch each page using curl/WebFetch to get raw HTML and HTTP headers
-3. Run through each of the 8 audit categories below
-4. Score each category using the rubric
-5. Generate GEO-TECHNICAL-AUDIT.md with results
+**This worker's domain:** Core Web Vitals, HTTPS, mobile, SSR/CSR detection, crawlability,
+security headers, URL structure, and page performance.
+AI crawler access in robots.txt is handled by `geo-crawlers`.
+llms.txt is handled by `geo-llmstxt`.
 
 ---
 
-## Category 1: Crawlability (15 points)
+## Scoring (0–100, 8 categories)
 
-### 1.1 robots.txt Validity
-- Fetch `https://[domain]/robots.txt`
-- Check for syntactic validity: proper `User-agent`, `Allow`, `Disallow` directives
-- Check for common errors: missing User-agent, wildcards blocking important paths, Disallow: / blocking entire site
-- Verify XML sitemap is referenced: `Sitemap: https://[domain]/sitemap.xml`
-
-### 1.2 AI Crawler Access (CRITICAL for GEO)
-Check robots.txt for directives targeting these AI crawlers:
-
-| Crawler | User-Agent | Platform |
-|---|---|---|
-| GPTBot | GPTBot | ChatGPT / OpenAI |
-| Google-Extended | Google-Extended | Gemini / Google AI training |
-| Googlebot | Googlebot | Google Search + AI Overviews |
-| Bingbot | bingbot | Bing Copilot + ChatGPT (via Bing) |
-| PerplexityBot | PerplexityBot | Perplexity AI |
-| ClaudeBot | ClaudeBot | Anthropic Claude |
-| Amazonbot | Amazonbot | Alexa / Amazon AI |
-| CCBot | CCBot | Common Crawl (used by many AI models) |
-| FacebookBot | FacebookExternalHit | Meta AI |
-| Bytespider | Bytespider | TikTok / ByteDance AI |
-| Applebot-Extended | Applebot-Extended | Apple Intelligence |
-
-**Scoring for AI crawler access:**
-- All major AI crawlers allowed: 5 points
-- Some blocked but Googlebot + Bingbot allowed: 3 points
-- GPTBot or PerplexityBot blocked: 1 point (significant GEO impact)
-- Googlebot blocked: 0 points (fatal)
-
-**Important nuance**: Blocking Google-Extended does NOT block Googlebot. Google-Extended only controls AI training data usage, not search indexing. However, blocking Google-Extended may reduce presence in AI Overviews. Recommend allowing Google-Extended unless there is a specific data licensing concern.
-
-### 1.3 XML Sitemaps
-- Fetch sitemap (check robots.txt for location, or try `/sitemap.xml`, `/sitemap_index.xml`)
-- Validate XML syntax
-- Check for `<lastmod>` dates (should be present and accurate)
-- Count URLs — compare to expected number of indexable pages
-- Check for sitemap index if large site (50,000+ URLs per sitemap max)
-- Verify all sitemap URLs return 200 status codes (sample check)
-
-### 1.4 Crawl Depth
-- Homepage = depth 0. Check that all important pages are reachable within **3 clicks** (depth 3)
-- Pages at depth 4+ receive significantly less crawl budget and are less likely to be cited by AI
-- Check internal linking: are key content pages linked from the homepage or main navigation?
-
-### 1.5 Noindex Management
-- Check for `<meta name="robots" content="noindex">` on pages that SHOULD be indexed
-- Check for `X-Robots-Tag: noindex` HTTP headers
-- Common mistakes: noindex on paginated pages, category pages, or key landing pages
-
-**Category Scoring:**
-| Check | Points |
+| Category | Max Points |
 |---|---|
-| robots.txt valid and complete | 3 |
-| AI crawlers allowed | 5 |
-| XML sitemap present and valid | 3 |
-| Crawl depth within 3 clicks | 2 |
-| No erroneous noindex directives | 2 |
+| Crawlability | 15 |
+| Indexability | 12 |
+| Security | 10 |
+| URL Structure | 8 |
+| Mobile Optimization | 10 |
+| Core Web Vitals | 15 |
+| Server-Side Rendering | 15 |
+| Page Speed & Server | 15 |
 
 ---
 
-## Category 2: Indexability (12 points)
+## Category Detail
 
-### 2.1 Canonical Tags
-- Every indexable page must have a `<link rel="canonical" href="...">` tag
-- Canonical must point to itself (self-referencing) for the authoritative version
-- Check for conflicting canonicals (canonical in HTML vs. HTTP header)
-- Check for canonical chains (A canonicals to B, B canonicals to C — should be A to C)
+### 1. Crawlability (15 pts)
 
-### 2.2 Duplicate Content
-- Check for www vs. non-www (both should resolve, one should redirect)
-- Check for HTTP vs. HTTPS (HTTP should redirect to HTTPS)
-- Check for trailing slash consistency (pick one pattern and redirect the other)
-- Check for parameter-based duplicates (`?sort=price` creating duplicate pages)
+- robots.txt valid and complete (3 pts)
+- AI crawlers allowed — check GPTBot, ClaudeBot, PerplexityBot, Google-Extended (5 pts)
+- XML sitemap present, valid, referenced in robots.txt (3 pts)
+- Key pages reachable within 3 clicks of homepage (2 pts)
+- No erroneous noindex on indexable pages (2 pts)
 
-### 2.3 Pagination
-- If paginated content exists, check for `rel="next"` / `rel="prev"` (note: Google ignores these as of 2019, but Bing still uses them)
-- Preferred: use `rel="canonical"` on paginated pages pointing to a view-all page or the first page
-- Ensure paginated pages are not noindexed if they contain unique content
+Note: `Google-Extended` controls AI training/AI Overviews — NOT standard search rank.
 
-### 2.4 Hreflang (international sites)
-- Check for `<link rel="alternate" hreflang="xx">` tags
-- Validate: reciprocal hreflang (if page A points to page B, B must point back to A)
-- Validate: x-default fallback exists
-- Check for language/region code validity (ISO 639-1 / ISO 3166-1)
+### 2. Indexability (12 pts)
 
-### 2.5 Index Bloat
-- Estimate number of indexed pages (check sitemap count, use `site:domain.com` estimate)
-- Compare indexed pages to actual valuable content pages
-- Flag if indexed pages significantly exceed content pages (index bloat from thin/duplicate/parameter pages)
+- Canonical tags: self-referencing, no chains, no conflicts with HTTP header (3 pts)
+- No duplicate content: www/non-www redirect, HTTP→HTTPS redirect, trailing-slash consistency (3 pts)
+- Pagination handled (2 pts)
+- Hreflang valid if international site (2 pts)
+- No index bloat from thin/parameter pages (2 pts)
 
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| Canonical tags correct on all pages | 3 |
-| No duplicate content issues | 3 |
-| Pagination handled correctly | 2 |
-| Hreflang correct (if applicable) | 2 |
-| No index bloat | 2 |
+### 3. Security (10 pts)
 
----
+- HTTPS enforced, valid cert, no mixed content (4 pts)
+- HSTS header present (2 pts)
+- X-Content-Type-Options: nosniff (1 pt)
+- X-Frame-Options: DENY or SAMEORIGIN (1 pt)
+- Referrer-Policy (1 pt)
+- Content-Security-Policy (1 pt)
 
-## Category 3: Security (10 points)
+### 4. URL Structure (8 pts)
 
-### 3.1 HTTPS Enforcement
-- Site must load over HTTPS
-- HTTP must redirect to HTTPS (301 redirect)
-- No mixed content warnings (HTTP resources on HTTPS pages)
-- SSL/TLS certificate must be valid and not expired
+- Human-readable URLs, lowercase, hyphens, no session IDs (2 pts)
+- Logical hierarchy reflecting site architecture (2 pts)
+- No redirect chains — max 1 hop (2 pts)
+- Parameter handling configured (2 pts)
 
-### 3.2 Security Headers
-Check HTTP response headers for:
+### 5. Mobile Optimization (10 pts)
 
-| Header | Required Value | Purpose |
-|---|---|---|
-| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Forces HTTPS |
-| `Content-Security-Policy` | Appropriate policy | Prevents XSS |
-| `X-Content-Type-Options` | `nosniff` | Prevents MIME sniffing |
-| `X-Frame-Options` | `DENY` or `SAMEORIGIN` | Prevents clickjacking |
-| `Referrer-Policy` | `strict-origin-when-cross-origin` or stricter | Controls referrer data |
-| `Permissions-Policy` | Appropriate restrictions | Controls browser features |
+Critical: Google crawls all sites exclusively with mobile Googlebot (since July 2024).
 
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| HTTPS enforced with valid cert | 4 |
-| HSTS header present | 2 |
-| X-Content-Type-Options | 1 |
-| X-Frame-Options | 1 |
-| Referrer-Policy | 1 |
-| Content-Security-Policy | 1 |
+- `<meta name="viewport" content="width=device-width, initial-scale=1">` (3 pts)
+- Responsive layout — no horizontal scroll (3 pts)
+- Tap targets ≥ 48×48 CSS pixels (2 pts)
+- Font sizes legible without zoom (2 pts)
 
----
+### 6. Core Web Vitals (15 pts)
 
-## Category 4: URL Structure (8 points)
-
-### 4.1 Clean URLs
-- URLs should be human-readable: `/blog/seo-guide` not `/blog?id=12345`
-- No session IDs in URLs
-- Lowercase only (no mixed case)
-- Hyphens for word separation (not underscores)
-- No special characters or encoded spaces
-
-### 4.2 Logical Hierarchy
-- URL path should reflect site architecture: `/category/subcategory/page`
-- Flat where appropriate — avoid unnecessarily deep nesting
-- Consistent pattern across the site
-
-### 4.3 Redirect Chains
-- Check for redirect chains (A redirects to B redirects to C)
-- Maximum 1 hop recommended (A redirects to C directly)
-- Check for redirect loops
-- All redirects should be 301 (permanent), not 302 (temporary), unless intentionally temporary
-
-### 4.4 Parameter Handling
-- URL parameters should not create duplicate indexable pages
-- Use canonical tags or `robots.txt` Disallow for parameter variations
-- Configure parameter handling in Google Search Console and Bing Webmaster Tools
-
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| Clean, readable URLs | 2 |
-| Logical hierarchy | 2 |
-| No redirect chains (max 1 hop) | 2 |
-| Parameter handling configured | 2 |
-
----
-
-## Category 5: Mobile Optimization (10 points)
-
-### Critical Context
-As of **July 2024**, Google crawls ALL sites exclusively with mobile Googlebot. There is no desktop crawling. If your site does not work on mobile, it does not work for Google. Period.
-
-### 5.1 Responsive Design
-- Check for `<meta name="viewport" content="width=device-width, initial-scale=1">`
-- Content must not require horizontal scrolling on mobile
-- No fixed-width layouts wider than viewport
-
-### 5.2 Tap Targets
-- Interactive elements (buttons, links) must be at least 48x48 CSS pixels
-- Minimum 8px spacing between tap targets
-- Check that navigation is usable on mobile
-
-### 5.3 Font Sizes
-- Base font size should be at least 16px
-- No text requiring zoom to read
-- Sufficient contrast ratio (WCAG AA: 4.5:1 for normal text, 3:1 for large text)
-
-### 5.4 Mobile Content Parity
-- All content visible on desktop must also be visible on mobile
-- No hidden content behind "read more" toggles that Googlebot cannot expand (though Google has improved at expanding these as of 2025)
-- Images and media must load on mobile
-
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| Viewport meta tag correct | 3 |
-| Responsive layout (no horizontal scroll) | 3 |
-| Tap targets appropriately sized | 2 |
-| Font sizes legible | 2 |
-
----
-
-## Category 6: Core Web Vitals (15 points)
-
-### 2026 Metrics and Thresholds
-Core Web Vitals use the **75th percentile** of real user data (field data) as the benchmark. Lab data is useful for debugging but field data determines the ranking signal.
-
-| Metric | Good | Needs Improvement | Poor | Notes |
-|---|---|---|---|---|
-| **LCP** (Largest Contentful Paint) | < 2.5s | 2.5s - 4.0s | > 4.0s | Measures loading — time until largest visible element renders |
-| **INP** (Interaction to Next Paint) | < 200ms | 200ms - 500ms | > 500ms | Replaced FID in March 2024. Measures ALL interactions, not just first |
-| **CLS** (Cumulative Layout Shift) | < 0.1 | 0.1 - 0.25 | > 0.25 | Measures visual stability — unexpected layout movements |
-
-### How to Assess Without CrUX Data
-When real user data is unavailable, estimate from page characteristics:
-- **LCP**: Check largest above-fold element. Is it an image (check size/format)? Is it text (check web font loading)? Server response time (TTFB)?
-- **INP**: Check for heavy JavaScript on page. Long tasks (>50ms) block interactivity. Check for third-party scripts.
-- **CLS**: Check for images without explicit width/height. Check for dynamically inserted content above the fold. Check for web fonts causing layout shift (FOUT/FOIT).
-
-### Common LCP Fixes
-1. Optimize hero images: WebP/AVIF format, correct sizing, preload with `<link rel="preload">`
-2. Reduce server response time (TTFB < 800ms)
-3. Eliminate render-blocking CSS/JS
-4. Preconnect to critical third-party origins
-
-### Common INP Fixes
-1. Break up long tasks (>50ms) into smaller chunks using `requestIdleCallback` or `scheduler.yield()`
-2. Reduce third-party JavaScript
-3. Use `content-visibility: auto` for off-screen content
-4. Debounce/throttle event handlers
-
-### Common CLS Fixes
-1. Always include `width` and `height` attributes on images and videos
-2. Reserve space for ads and embeds with CSS `aspect-ratio` or explicit dimensions
-3. Use `font-display: swap` with size-adjusted fallback fonts
-4. Avoid inserting content above existing content after page load
-
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| LCP < 2.5s | 5 |
-| INP < 200ms | 5 |
-| CLS < 0.1 | 5 |
-
----
-
-## Category 7: Server-Side Rendering (15 points) — CRITICAL FOR GEO
-
-### Why SSR Is Mandatory for AI Visibility
-AI crawlers (GPTBot, PerplexityBot, ClaudeBot, etc.) do **NOT execute JavaScript**. They fetch the raw HTML and parse it. If your content is rendered client-side by React, Vue, Angular, or any other JavaScript framework, AI crawlers see an empty page.
-
-Even Googlebot, which does execute JavaScript, deprioritizes JS-rendered content due to the additional crawl budget required. Google processes JS rendering in a separate "rendering queue" that can delay indexing by days or weeks.
-
-### Detection Method
-1. Fetch the page with curl (no JavaScript execution): `curl -s [URL]`
-2. Compare the raw HTML to the rendered DOM (via browser)
-3. If key content (headings, paragraphs, product info, article text) is MISSING from the curl output, the site relies on client-side rendering
-
-### What to Check
-- **Main content text**: Is the article body / product description / page content in the raw HTML?
-- **Headings**: Are H1, H2, H3 tags present in raw HTML?
-- **Navigation**: Is the main navigation server-rendered?
-- **Structured data**: Is JSON-LD in the raw HTML or injected by JavaScript?
-- **Meta tags**: Are title, description, canonical, OG tags in the raw HTML?
-- **Internal links**: Are navigation and content links in the raw HTML? (Critical for crawlability)
-
-### SSR Solutions to Recommend
-| Framework | SSR Solution |
-|---|---|
-| React | Next.js (SSR/SSG), Remix, Gatsby (SSG) |
-| Vue | Nuxt.js (SSR/SSG) |
-| Angular | Angular Universal |
-| Svelte | SvelteKit |
-| Generic | Prerender.io (prerendering service), Rendertron |
-
-### Scoring Detail
-- All key content server-rendered: 15 points
-- Main content server-rendered but some elements JS-only: 10 points
-- Critical content requires JS (product info, article text): 5 points
-- Entire page is client-rendered (empty body in raw HTML): 0 points
-
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| Main content in raw HTML | 8 |
-| Meta tags + structured data in raw HTML | 4 |
-| Internal links in raw HTML | 3 |
-
----
-
-## Category 8: Page Speed & Server Performance (15 points)
-
-### 8.1 Time to First Byte (TTFB)
-- Target: **< 800ms** (ideally < 200ms)
-- Measure with curl: `curl -o /dev/null -s -w 'TTFB: %{time_starttransfer}s\n' [URL]`
-- If TTFB > 800ms: check server location, caching, database queries, CDN usage
-
-### 8.2 Resource Optimization
-- Total page weight target: **< 2MB** (critical pages < 1MB)
-- Check for uncompressed resources (gzip/brotli compression should be enabled)
-- Check for unminified CSS and JavaScript
-- Check for unused CSS/JS (can represent 50%+ of downloaded bytes on many sites)
-
-### 8.3 Image Optimization
-- Check image formats: WebP or AVIF preferred over JPEG/PNG
-- Check for oversized images (images larger than display size)
-- Check for lazy loading: images below fold should have `loading="lazy"`
-- Check for explicit dimensions (width/height attributes prevent CLS)
-- Above-fold images should NOT be lazy loaded (harms LCP)
-
-### 8.4 Code Splitting and Lazy Loading
-- JavaScript should be code-split so each page only loads what it needs
-- Check for large JavaScript bundles (> 200KB compressed is a warning, > 500KB is critical)
-- Third-party scripts should load asynchronously (`async` or `defer`)
-- Check for render-blocking resources in `<head>`
-
-### 8.5 Caching
-- Check `Cache-Control` headers on static resources (images, CSS, JS)
-- Static assets should have long cache times: `max-age=31536000` (1 year) with content-hashed filenames
-- HTML pages should have shorter cache or `no-cache` with validation (`ETag` or `Last-Modified`)
-
-### 8.6 CDN Usage
-- Check if static resources are served from a CDN (different domain or CDN-specific headers)
-- For global audience, CDN is critical for consistent performance
-- Check for CDN-specific headers: `CF-Ray` (Cloudflare), `X-Cache` (AWS CloudFront), `X-Served-By` (Fastly)
-
-**Category Scoring:**
-| Check | Points |
-|---|---|
-| TTFB < 800ms | 3 |
-| Page weight < 2MB | 2 |
-| Images optimized (format, size, lazy) | 3 |
-| JS bundles reasonable (< 200KB compressed) | 2 |
-| Compression enabled (gzip/brotli) | 2 |
-| Cache headers on static resources | 2 |
-| CDN in use | 1 |
-
----
-
-## IndexNow Protocol
-
-### What It Is
-IndexNow is an open protocol that allows websites to notify search engines instantly when content is created, updated, or deleted. Supported by Bing, Yandex, Seznam, and Naver. Google does NOT support IndexNow but monitors the protocol.
-
-### Why It Matters for GEO
-ChatGPT uses Bing's index. Bing Copilot uses Bing's index. Faster Bing indexing means faster AI visibility on two major platforms.
-
-### Implementation Check
-1. Check for IndexNow key file: `https://[domain]/.well-known/indexnow-key.txt` or similar
-2. Check if CMS has IndexNow plugin (WordPress: IndexNow plugin; many modern CMS platforms support it natively)
-3. If not implemented, recommend adding it with instructions
-
----
-
-## Overall Scoring
-
-| Category | Max Points | Weight |
-|---|---|---|
-| Crawlability | 15 | Core foundation |
-| Indexability | 12 | Core foundation |
-| Security | 10 | Trust signal |
-| URL Structure | 8 | Crawl efficiency |
-| Mobile Optimization | 10 | Google requirement |
-| Core Web Vitals | 15 | Ranking signal |
-| Server-Side Rendering | 15 | GEO critical |
-| Page Speed & Server | 15 | Performance |
-| **Total** | **100** | |
-
-### Score Interpretation
-- **90-100**: Excellent — technically sound for both traditional SEO and GEO
-- **70-89**: Good — minor issues to address but fundamentally solid
-- **50-69**: Needs Work — significant technical debt impacting visibility
-- **30-49**: Poor — major issues blocking crawling, indexing, or AI visibility
-- **0-29**: Critical — fundamental technical failures requiring immediate attention
-
----
-
-## Output Format
-
-Generate **GEO-TECHNICAL-AUDIT.md** with:
-
-```markdown
-# GEO Technical SEO Audit — [Domain]
-Date: [Date]
-
-## Technical Score: XX/100
-
-## Score Breakdown
-| Category | Score | Status |
-|---|---|---|
-| Crawlability | XX/15 | Pass/Warn/Fail |
-| Indexability | XX/12 | Pass/Warn/Fail |
-| Security | XX/10 | Pass/Warn/Fail |
-| URL Structure | XX/8 | Pass/Warn/Fail |
-| Mobile Optimization | XX/10 | Pass/Warn/Fail |
-| Core Web Vitals | XX/15 | Pass/Warn/Fail |
-| Server-Side Rendering | XX/15 | Pass/Warn/Fail |
-| Page Speed & Server | XX/15 | Pass/Warn/Fail |
-
-Status: Pass = 80%+ of category points, Warn = 50-79%, Fail = <50%
-
-## AI Crawler Access
-| Crawler | User-Agent | Status | Recommendation |
+| Metric | Good | Needs Improvement | Poor |
 |---|---|---|---|
-| GPTBot | GPTBot | Allowed/Blocked | [Action] |
-| Googlebot | Googlebot | Allowed/Blocked | [Action] |
-[Continue for all AI crawlers]
+| LCP (Largest Contentful Paint) | < 2.5s | 2.5–4.0s | > 4.0s |
+| INP (Interaction to Next Paint) | < 200ms | 200–500ms | > 500ms |
+| CLS (Cumulative Layout Shift) | < 0.1 | 0.1–0.25 | > 0.25 |
 
-## Critical Issues (fix immediately)
-[List with specific page URLs and what is wrong]
+INP replaced FID in March 2024. Measures all interactions, not just first.
 
-## Warnings (fix this month)
-[List with details]
+5 pts per metric. Estimate from page characteristics when CrUX data unavailable:
+- LCP: check largest above-fold element, TTFB
+- INP: check for heavy JS, long tasks >50ms, third-party scripts
+- CLS: check for images without explicit dimensions, dynamically inserted content
 
-## Recommendations (optimize this quarter)
-[List with details]
+### 7. Server-Side Rendering — CRITICAL FOR GEO (15 pts)
 
-## Detailed Findings
-[Per-category breakdown with evidence]
+**AI crawlers do NOT execute JavaScript.** If content is client-side rendered, AI crawlers
+see an empty page.
+
+Assessment: fetch raw HTML with no JS execution. Compare to rendered DOM.
+
+| Check | Points |
+|---|---|
+| Main content (headings, body text) in raw HTML | 8 |
+| Meta tags + JSON-LD structured data in raw HTML | 4 |
+| Internal navigation links in raw HTML | 3 |
+
+If client-side rendered, recommend: Next.js/Remix (React), Nuxt (Vue), SvelteKit,
+or Prerender.io for existing apps.
+
+### 8. Page Speed & Server (15 pts)
+
+- TTFB < 800ms (3 pts) — measure: `curl -o /dev/null -s -w 'TTFB: %{time_starttransfer}s\n' <url>`
+- Page weight < 2MB, key pages < 1MB (2 pts)
+- Images: WebP/AVIF, explicit dimensions, lazy load below fold (3 pts)
+- JS bundles < 200KB compressed (2 pts)
+- Compression: gzip/brotli enabled (2 pts)
+- Cache-Control headers on static assets (2 pts)
+- CDN in use (1 pt)
+
+---
+
+## Score Interpretation
+
+| Range | Rating |
+|---|---|
+| 90–100 | Excellent — technically sound for SEO and GEO |
+| 70–89 | Good — minor issues |
+| 50–69 | Needs Work — significant technical debt |
+| 30–49 | Poor — major issues blocking visibility |
+| 0–29 | Critical — fundamental failures |
+
+---
+
+## Worker Return Format
+
+```json
+{
+  "score": 51,
+  "critical_3": [
+    "Site is client-side rendered — AI crawlers see empty HTML body",
+    "GPTBot blocked via User-agent: * Disallow: /",
+    "LCP estimated at 4.2s — hero image 1.2MB uncompressed JPEG"
+  ],
+  "quick_wins_3": [
+    "Enable SSR or prerendering — Next.js if already on React",
+    "Add explicit GPTBot Allow: / to robots.txt",
+    "Convert hero image to WebP, add width/height attributes, preload with rel=preload"
+  ]
+}
 ```


### PR DESCRIPTION
## Summary

Phase 1 of the OpenClaw migration — rewrites all 9 sub-skill SKILL.md files as methodology guides and adds 8 worker task specs.

## Changes

### Skill surface rewrites (9 files)

- **`geo/SKILL.md`** — cleaned command table, scoring weights, quality gates
- **`geo-audit`** — orchestrator-only: discovery flow, worker delegation table, synthesis formula, depth presets, inline output format
- **`geo-citability`** — passage-level rubric (5 categories + weights), script invocation, worker return contract
- **`geo-crawlers`** — 3-tier crawler reference, scoring formula, recommended robots.txt template
- **`geo-llmstxt`** — format spec with all format rules, validation checklist, scoring dimensions, generation mode
- **`geo-brand-mentions`** — platform weight table, stub status and capability matrix, per-platform scoring guides
- **`geo-schema`** — GEO-critical schema types, sameAs strategy, deprecated schema table, scoring rubric
- **`geo-technical`** — 8 categories with point breakdowns, SSR critical section, CWV 2026 thresholds
- **`geo-content`** — full E-E-A-T rubric per dimension, topical authority modifier, AI content quality flags
- **`geo-platform-optimizer`** — stub with platform priority reference table, input contract stub

### Worker task specs (8 new files in `references/workers/`)

Each spec defines: task steps, script invocation, return JSON schema, and depth presets for full vs quick mode.

## What was removed

- All `allowed-tools:` frontmatter keys (not valid in OpenClaw)
- All file-write output sections (inline artefacts only — no disk writes)
- All references to deleted sub-skills (geo-report, geo-prospect, geo-compare, etc.)
- Old Claude Code agent orchestration patterns

## Stubs (by design)

- `geo-brand-mentions` — Wikipedia/YouTube functional, Reddit/LinkedIn search fallbacks. Pending issue #3.
- `geo-platform-optimizer` — placeholder pending issue #2 input contract definition.

## Related

Closes #6