### PR TITLE
Phase 4: Node.js script migration (fetch-page, citability-scorer, llmstxt-generator)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/copilot-review-notify.yml
+++ b/.github/workflows/copilot-review-notify.yml
@@ -18,7 +18,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg agentId "krennic" \
-            --arg message "Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}). Review state: ${REVIEW_STATE}. URL: ${PR_URL}. Notify the team in one sentence." \
+            --arg message "Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, push the fixes to the same branch, resolve all threads via GraphQL, then re-request a Copilot review. Repeat until no unresolved threads remain and CI is green." \
             --argjson deliver true \
             --arg channel "discord" \
             --arg to "${{ secrets.OPENCLAW_DISCORD_CHANNEL_ID }}" \

--- a/.github/workflows/copilot-review-notify.yml
+++ b/.github/workflows/copilot-review-notify.yml
@@ -18,7 +18,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg agentId "krennic" \
-            --arg message "<@1478200403743998014> Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
+            --arg message "<@${{ secrets.OPENCLAW_KRENNIC_BOT_ID }}> Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
             --argjson deliver true \
             --arg channel "discord" \
             --arg to "${{ secrets.OPENCLAW_DISCORD_CHANNEL_ID }}" \

--- a/.github/workflows/copilot-review-notify.yml
+++ b/.github/workflows/copilot-review-notify.yml
@@ -18,7 +18,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg agentId "krennic" \
-            --arg message "Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
+            --arg message "<@1478200403743998014> Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
             --argjson deliver true \
             --arg channel "discord" \
             --arg to "${{ secrets.OPENCLAW_DISCORD_CHANNEL_ID }}" \

--- a/.github/workflows/copilot-review-notify.yml
+++ b/.github/workflows/copilot-review-notify.yml
@@ -18,7 +18,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg agentId "krennic" \
-            --arg message "<@${{ secrets.OPENCLAW_KRENNIC_BOT_ID }}> Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
+            --arg message "<@${{ secrets.OPENCLAW_KRENNIC_BOT_ID }}> Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: ${{ github.repository }}. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
             --argjson deliver true \
             --arg channel "discord" \
             --arg to "${{ secrets.OPENCLAW_DISCORD_CHANNEL_ID }}" \

--- a/.github/workflows/copilot-review-notify.yml
+++ b/.github/workflows/copilot-review-notify.yml
@@ -18,7 +18,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg agentId "krennic" \
-            --arg message "Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, push the fixes to the same branch, resolve all threads via GraphQL, then re-request a Copilot review. Repeat until no unresolved threads remain and CI is green." \
+            --arg message "Copilot just reviewed PR #${PR_NUMBER} (${PR_TITLE}) with state: ${REVIEW_STATE}. PR URL: ${PR_URL}. Repo: MiguelTVMS/geo-seo-openclaw. Fetch all unresolved review threads on this PR, fix every issue in the codebase, run the tests, push the fixes to the same branch, resolve ALL review threads via GraphQL mutation (every single one — no exceptions), then re-request a Copilot review. Repeat this loop until there are zero unresolved threads and CI is green." \
             --argjson deliver true \
             --arg channel "discord" \
             --arg to "${{ secrets.OPENCLAW_DISCORD_CHANNEL_ID }}" \

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -30,16 +30,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         id: tests
@@ -68,7 +68,7 @@ jobs:
 
       - name: Post CI summary comment
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const steps = {

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,3 @@ PLAN_REVIEW.md
 
 # Node.js
 node_modules/
-package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,315 @@
+{
+  "name": "geo-seo-openclaw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "geo-seo-openclaw",
+      "version": "0.1.0",
+      "dependencies": {
+        "cheerio": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.14.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -1,0 +1,292 @@
+/**
+ * citability-scorer.mjs — Passage-level AI citation readiness scorer
+ *
+ * Analyses content blocks on a page and scores them for AI citability (0-100).
+ * Based on research showing optimal AI-cited passages are 134-167 words,
+ * self-contained, fact-rich, and structured with clear answer patterns.
+ *
+ * Usage: node scripts/citability-scorer.mjs --url <url>
+ * Output: JSON to stdout. Errors to stderr, exit code 1.
+ */
+
+import * as cheerio from 'cheerio';
+import { fetchPage } from './fetch-page.mjs';
+
+// ---------------------------------------------------------------------------
+// Score a single passage for AI citability (0-100)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} text
+ * @param {string|null} heading
+ * @returns {object}
+ */
+export function scorePassage(text, heading = null) {
+  const words = text.trim().split(/\s+/);
+  const wordCount = words.length;
+
+  const scores = {
+    answer_block_quality: 0,
+    self_containment: 0,
+    structural_readability: 0,
+    statistical_density: 0,
+    uniqueness_signals: 0,
+  };
+
+  // === 1. Answer Block Quality (30%) ===
+  let abq = 0;
+
+  const definitionPatterns = [
+    /\b\w+\s+is\s+(?:a|an|the)\s/i,
+    /\b\w+\s+refers?\s+to\s/i,
+    /\b\w+\s+means?\s/i,
+    /\b\w+\s+(?:can be |are )?defined\s+as\s/i,
+    /\bin\s+(?:simple|other)\s+(?:terms|words)\s*,/i,
+  ];
+  if (definitionPatterns.some((p) => p.test(text))) abq += 15;
+
+  const first60 = words.slice(0, 60).join(' ');
+  if (
+    [/\b(?:is|are|was|were|means?|refers?)\b/i, /\d+%/, /\$[\d,]+/, /\d+\s+(?:million|billion|thousand)/i].some(
+      (p) => p.test(first60)
+    )
+  )
+    abq += 15;
+
+  if (heading && heading.endsWith('?')) abq += 10;
+
+  const sentences = text.split(/[.!?]+/).filter((s) => s.trim().length > 0);
+  const shortClear = sentences.filter((s) => {
+    const wc = s.trim().split(/\s+/).length;
+    return wc >= 5 && wc <= 25;
+  }).length;
+  if (sentences.length > 0) abq += Math.floor((shortClear / sentences.length) * 10);
+
+  if (
+    /(?:according to|research shows|studies? (?:show|indicate|suggest|found)|data (?:shows|indicates|suggests))/i.test(
+      text
+    )
+  )
+    abq += 10;
+
+  scores.answer_block_quality = Math.min(abq, 30);
+
+  // === 2. Self-Containment (25%) ===
+  let sc = 0;
+
+  if (wordCount >= 134 && wordCount <= 167) sc += 10;
+  else if (wordCount >= 100 && wordCount <= 200) sc += 7;
+  else if (wordCount >= 80 && wordCount <= 250) sc += 4;
+  else if (wordCount < 30 || wordCount > 400) sc += 0;
+  else sc += 2;
+
+  const pronounCount = (
+    text.match(/\b(?:it|they|them|their|this|that|these|those|he|she|his|her)\b/gi) || []
+  ).length;
+  if (wordCount > 0) {
+    const ratio = pronounCount / wordCount;
+    if (ratio < 0.02) sc += 8;
+    else if (ratio < 0.04) sc += 5;
+    else if (ratio < 0.06) sc += 3;
+  }
+
+  const properNouns = (text.match(/\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\b/g) || []).length;
+  if (properNouns >= 3) sc += 7;
+  else if (properNouns >= 1) sc += 4;
+
+  scores.self_containment = Math.min(sc, 25);
+
+  // === 3. Structural Readability (20%) ===
+  let sr = 0;
+
+  if (sentences.length > 0) {
+    const avg = wordCount / sentences.length;
+    if (avg >= 10 && avg <= 20) sr += 8;
+    else if (avg >= 8 && avg <= 25) sr += 5;
+    else sr += 2;
+  }
+
+  if (/(?:first|second|third|finally|additionally|moreover|furthermore)/i.test(text)) sr += 4;
+  if (/(?:\d+[\.\)]\s|\b(?:step|tip|point)\s+\d+)/i.test(text)) sr += 4;
+  if (/\n/.test(text)) sr += 4;
+
+  scores.structural_readability = Math.min(sr, 20);
+
+  // === 4. Statistical Density (15%) ===
+  let sd = 0;
+
+  const pctCount = (text.match(/\d+(?:\.\d+)?%/g) || []).length;
+  sd += Math.min(pctCount * 3, 6);
+
+  const dollarCount = (text.match(/\$[\d,]+(?:\.\d+)?(?:\s*(?:million|billion|M|B|K))?/g) || []).length;
+  sd += Math.min(dollarCount * 3, 5);
+
+  const numberCount = (
+    text.match(
+      /\b\d+(?:,\d{3})*(?:\.\d+)?\s+(?:users|customers|pages|sites|companies|businesses|people|percent|times|x\b)/gi
+    ) || []
+  ).length;
+  sd += Math.min(numberCount * 2, 4);
+
+  if (/\b20(?:2[3-6]|1\d)\b/.test(text)) sd += 2;
+
+  const sourcePatterns = [
+    /(?:according to|per|from|by)\s+[A-Z]/,
+    /(?:Gartner|Forrester|McKinsey|Harvard|Stanford|MIT|Google|Microsoft|OpenAI|Anthropic)/,
+    /\([A-Z][a-z]+(?:\s+\d{4})?\)/,
+  ];
+  for (const p of sourcePatterns) {
+    if (p.test(text)) { sd += 2; break; }
+  }
+
+  scores.statistical_density = Math.min(sd, 15);
+
+  // === 5. Uniqueness Signals (10%) ===
+  let us = 0;
+
+  if (/(?:our (?:research|study|data|analysis|survey|findings)|we (?:found|discovered|analyzed|surveyed|measured))/i.test(text))
+    us += 5;
+  if (/(?:case study|for example|for instance|in practice|real-world|hands-on)/i.test(text))
+    us += 3;
+  if (/(?:using|with|via|through)\s+[A-Z][a-z]+/.test(text))
+    us += 2;
+
+  scores.uniqueness_signals = Math.min(us, 10);
+
+  // === Total ===
+  const total = Object.values(scores).reduce((a, b) => a + b, 0);
+
+  let grade, label;
+  if (total >= 80) { grade = 'A'; label = 'Highly Citable'; }
+  else if (total >= 65) { grade = 'B'; label = 'Good Citability'; }
+  else if (total >= 50) { grade = 'C'; label = 'Moderate Citability'; }
+  else if (total >= 35) { grade = 'D'; label = 'Low Citability'; }
+  else { grade = 'F'; label = 'Poor Citability'; }
+
+  return {
+    heading,
+    word_count: wordCount,
+    total_score: total,
+    grade,
+    label,
+    breakdown: scores,
+    preview: words.slice(0, 30).join(' ') + (wordCount > 30 ? '...' : ''),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Analyse all content blocks on a page
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url
+ * @param {{ fetchFn?: Function }} options
+ * @returns {Promise<object>}
+ */
+export async function analyzePageCitability(url, { fetchFn } = {}) {
+  const pageData = await fetchPage(url, fetchFn ? { fetchFn } : {});
+
+  if (pageData.errors.length > 0 && !pageData.status_code) {
+    return { url, error: pageData.errors.join('; ') };
+  }
+
+  // Parse HTML again with cheerio for block extraction
+  const $ = cheerio.load(pageData.text_content ? await refetchHtml(url, fetchFn) : '');
+
+  // Remove non-content elements
+  $('script, style, nav, footer, header, aside, form').each((_, el) => $(el).remove());
+
+  const blocks = [];
+  let currentHeading = 'Introduction';
+  let currentParagraphs = [];
+
+  $('h1, h2, h3, h4, p, ul, ol, table').each((_, el) => {
+    const tag = el.tagName?.toLowerCase() || '';
+    if (/^h[1-4]$/.test(tag)) {
+      if (currentParagraphs.length > 0) {
+        const combined = currentParagraphs.join(' ');
+        if (combined.split(/\s+/).length >= 20) {
+          blocks.push({ heading: currentHeading, content: combined });
+        }
+      }
+      currentHeading = $(el).text().trim();
+      currentParagraphs = [];
+    } else {
+      const text = $(el).text().trim();
+      if (text && text.split(/\s+/).length >= 5) {
+        currentParagraphs.push(text);
+      }
+    }
+  });
+
+  if (currentParagraphs.length > 0) {
+    const combined = currentParagraphs.join(' ');
+    if (combined.split(/\s+/).length >= 20) {
+      blocks.push({ heading: currentHeading, content: combined });
+    }
+  }
+
+  const scoredBlocks = blocks.map((b) => scorePassage(b.content, b.heading));
+
+  const avgScore =
+    scoredBlocks.length > 0
+      ? scoredBlocks.reduce((a, b) => a + b.total_score, 0) / scoredBlocks.length
+      : 0;
+
+  const sorted = [...scoredBlocks].sort((a, b) => b.total_score - a.total_score);
+  const topBlocks = sorted.slice(0, 5);
+  const bottomBlocks = [...scoredBlocks].sort((a, b) => a.total_score - b.total_score).slice(0, 5);
+  const optimalCount = scoredBlocks.filter((b) => b.word_count >= 134 && b.word_count <= 167).length;
+
+  const gradeDist = { A: 0, B: 0, C: 0, D: 0, F: 0 };
+  for (const b of scoredBlocks) gradeDist[b.grade]++;
+
+  // Worker return format (for geo-audit integration)
+  const overallScore = Math.round(avgScore);
+
+  return {
+    url,
+    overall_score: overallScore,
+    total_blocks_analyzed: scoredBlocks.length,
+    average_citability_score: Math.round(avgScore * 10) / 10,
+    optimal_length_passages: optimalCount,
+    grade_distribution: gradeDist,
+    top_5_citable: topBlocks,
+    bottom_5_citable: bottomBlocks,
+    blocks: scoredBlocks,
+  };
+}
+
+// Refetch raw HTML for block extraction (separate from fetchPage's text_content)
+async function refetchHtml(url, fetchFn) {
+  const fn = fetchFn || fetch;
+  try {
+    const res = await fn(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+      },
+    });
+    return await res.text();
+  } catch {
+    return '';
+  }
+}
+
+// CLI entrypoint
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const args = process.argv.slice(2);
+  const urlIdx = args.indexOf('--url');
+
+  if (urlIdx === -1 || !args[urlIdx + 1]) {
+    process.stderr.write('Usage: node scripts/citability-scorer.mjs --url <url>\n');
+    process.exit(1);
+  }
+
+  analyzePageCitability(args[urlIdx + 1])
+    .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))
+    .catch((err) => {
+      process.stderr.write(`Fatal: ${err.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -186,7 +186,7 @@ export function scorePassage(text, heading = null) {
  * @returns {Promise<object>}
  */
 export async function analyzePageCitability(url, { fetchFn } = {}) {
-  const pageData = await fetchPage(url, fetchFn ? { fetchFn } : {});
+  const pageData = await fetchPage(url, fetchFn ? { fetchFn, includeHtml: true } : { includeHtml: true });
 
   if (pageData.errors.length > 0 && !pageData.status_code) {
     return { url, error: pageData.errors.join('; ') };

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -200,7 +200,8 @@ export async function analyzePageCitability(url, { fetchFn } = {}) {
 
   // Reuse HTML from fetchPage if available; refetch only as fallback
   // This avoids a second network request for the same URL
-  const html = pageData.html || await refetchHtml(url, fetchFn);
+  const effectiveUrl = pageData.url || url;
+  const html = pageData.html || await refetchHtml(effectiveUrl, fetchFn);
   const $ = cheerio.load(html || '');
 
   // Remove non-content elements

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -188,8 +188,14 @@ export function scorePassage(text, heading = null) {
 export async function analyzePageCitability(url, { fetchFn } = {}) {
   const pageData = await fetchPage(url, fetchFn ? { fetchFn, includeHtml: true } : { includeHtml: true });
 
-  if (pageData.errors.length > 0 && !pageData.status_code) {
-    return { url, error: pageData.errors.join('; ') };
+  // Gate on real network failure (status_code null = never got a response)
+  // not on errors[] which can contain non-fatal warnings (e.g. invalid JSON-LD)
+  if (pageData.status_code == null) {
+    const message =
+      Array.isArray(pageData.errors) && pageData.errors.length > 0
+        ? pageData.errors.join('; ')
+        : 'Failed to fetch page content';
+    return { url, error: message };
   }
 
   // Reuse HTML from fetchPage if available; refetch only as fallback

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -133,7 +133,7 @@ export function scorePassage(text, heading = null) {
   if (/\b20(?:2[3-6]|1\d)\b/.test(text)) sd += 2;
 
   const sourcePatterns = [
-    /(?:according to|per|from|by)\s+[A-Z]/,
+    /(?:according to|per|from|by)\s+[A-Z]/i,
     /(?:Gartner|Forrester|McKinsey|Harvard|Stanford|MIT|Google|Microsoft|OpenAI|Anthropic)/,
     /\([A-Z][a-z]+(?:\s+\d{4})?\)/,
   ];

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -192,8 +192,9 @@ export async function analyzePageCitability(url, { fetchFn } = {}) {
     return { url, error: pageData.errors.join('; ') };
   }
 
-  // Always refetch raw HTML for block extraction unless fetchPage failed entirely
-  const html = await refetchHtml(url, fetchFn);
+  // Reuse HTML from fetchPage if available; refetch only as fallback
+  // This avoids a second network request for the same URL
+  const html = pageData.html || await refetchHtml(url, fetchFn);
   const $ = cheerio.load(html || '');
 
   // Remove non-content elements

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -22,7 +22,8 @@ import { fetchPage } from './fetch-page.mjs';
  * @returns {object}
  */
 export function scorePassage(text, heading = null) {
-  const words = text.trim().split(/\s+/);
+  const trimmedText = text.trim();
+  const words = trimmedText === '' ? [] : trimmedText.split(/\s+/);
   const wordCount = words.length;
 
   const scores = {

--- a/scripts/citability-scorer.mjs
+++ b/scripts/citability-scorer.mjs
@@ -9,6 +9,7 @@
  * Output: JSON to stdout. Errors to stderr, exit code 1.
  */
 
+import { fileURLToPath } from 'node:url';
 import * as cheerio from 'cheerio';
 import { fetchPage } from './fetch-page.mjs';
 
@@ -191,8 +192,9 @@ export async function analyzePageCitability(url, { fetchFn } = {}) {
     return { url, error: pageData.errors.join('; ') };
   }
 
-  // Parse HTML again with cheerio for block extraction
-  const $ = cheerio.load(pageData.text_content ? await refetchHtml(url, fetchFn) : '');
+  // Always refetch raw HTML for block extraction unless fetchPage failed entirely
+  const html = await refetchHtml(url, fetchFn);
+  const $ = cheerio.load(html || '');
 
   // Remove non-content elements
   $('script, style, nav, footer, header, aside, form').each((_, el) => $(el).remove());
@@ -275,19 +277,39 @@ async function refetchHtml(url, fetchFn) {
 }
 
 // CLI entrypoint
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
+
+  if (args.includes('--help')) {
+    process.stdout.write(
+      'Usage: node scripts/citability-scorer.mjs --url <url>\n\n' +
+      'Options:\n' +
+      '  --url <url>  URL to analyse (required)\n' +
+      '  --help       Show this help message\n\n' +
+      'Output: JSON to stdout. On error, JSON error object to stdout + message to stderr.\n'
+    );
+    process.exit(0);
+  }
+
   const urlIdx = args.indexOf('--url');
 
   if (urlIdx === -1 || !args[urlIdx + 1]) {
-    process.stderr.write('Usage: node scripts/citability-scorer.mjs --url <url>\n');
+    process.stderr.write('Error: --url is required\n');
+    process.stderr.write('Run with --help for usage.\n');
+    process.stdout.write(JSON.stringify({ error: '--url is required' }) + '\n');
     process.exit(1);
   }
 
   analyzePageCitability(args[urlIdx + 1])
     .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))
     .catch((err) => {
-      process.stderr.write(`Fatal: ${err.message}\n`);
+      const msg = err?.message ?? 'Unknown error';
+      process.stderr.write(`Fatal: ${msg}\n`);
+      try {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } catch {
+        process.stdout.write('{"error":"Unknown error"}\n');
+      }
       process.exit(1);
     });
 }

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -29,7 +29,7 @@ const SECURITY_HEADERS = [
   'referrer-policy',
 ];
 
-const FRAMEWORK_ROOT_RE = /^(app|root|__next|__nuxt)$/i;
+const FRAMEWORK_ROOT_RE = /(app|root|__next|__nuxt)/i;
 
 /**
  * Fetch a page and return structured analysis data.
@@ -64,11 +64,34 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
   const timer = setTimeout(() => controller.abort(), timeout * 1000);
 
   try {
-    const response = await fetchFn(url, {
-      headers: DEFAULT_HEADERS,
-      redirect: 'follow',
-      signal: controller.signal,
-    });
+    // Manually follow redirects to populate redirect_chain
+    const MAX_REDIRECTS = 10;
+    let currentUrl = url;
+    let response;
+
+    for (let i = 0; i < MAX_REDIRECTS; i++) {
+      response = await fetchFn(currentUrl, {
+        headers: DEFAULT_HEADERS,
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+
+      const status = response.status;
+      if (status >= 300 && status < 400) {
+        const location = response.headers.get('location');
+        if (!location) break;
+        const nextUrl = new URL(location, currentUrl).toString();
+        result.redirect_chain.push({ url: nextUrl, status });
+        currentUrl = nextUrl;
+        continue;
+      }
+      break;
+    }
+
+    if (!response) throw new Error('No response received');
+    if (response.status >= 300 && response.status < 400) {
+      result.errors.push('Too many redirects');
+    }
 
     result.status_code = response.status;
 
@@ -207,7 +230,14 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   }
 
   const url = args[urlIdx + 1];
-  const timeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1], 10) : 30;
+  let timeout = 30;
+  if (timeoutIdx !== -1) {
+    const rawTimeout = args[timeoutIdx + 1];
+    const parsedTimeout = Number.parseInt(rawTimeout, 10);
+    if (Number.isFinite(parsedTimeout) && parsedTimeout > 0) {
+      timeout = parsedTimeout;
+    }
+  }
 
   fetchPage(url, { timeout })
     .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -142,8 +142,18 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     // JSON-LD structured data — must run BEFORE decompose()
     $('script[type="application/ld+json"]').each((_, el) => {
       try {
-        const data = JSON.parse($(el).html());
-        result.structured_data.push(data);
+        const raw = $(el).html();
+        // Guard against empty/missing JSON-LD content; treat as invalid
+        if (raw == null || raw.trim() === '') {
+          result.errors.push('Invalid JSON-LD detected');
+          return;
+        }
+        const data = JSON.parse(raw);
+        if (data !== null && (Array.isArray(data) || typeof data === 'object')) {
+          result.structured_data.push(data);
+        } else {
+          result.errors.push('Invalid JSON-LD detected');
+        }
       } catch {
         result.errors.push('Invalid JSON-LD detected');
       }

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -103,8 +103,12 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     if (redirectLimitExceeded) {
       result.errors.push('Too many redirects');
       result.status_code = response.status;
+      result.url = currentUrl;
       // Skip HTML parsing — response is a redirect, not page content
     } else {
+    // Record effective URL and status after following redirects
+    result.status_code = response.status;
+    result.url = currentUrl;
 
     // Collect response headers
     const rawHeaders = {};

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -1,0 +1,218 @@
+/**
+ * fetch-page.mjs — GEO page fetcher and SSR heuristic
+ *
+ * Fetches a URL and returns structured analysis data including:
+ * - HTML metadata (title, description, canonical, headings)
+ * - Structured data (JSON-LD)
+ * - Internal/external links and images
+ * - Security headers
+ * - SSR detection (Issue #19: dual-condition guard prevents false positives)
+ *
+ * Usage: node scripts/fetch-page.mjs --url <url> [--timeout <seconds>]
+ * Output: JSON to stdout. Errors to stderr, exit code 1.
+ */
+
+import * as cheerio from 'cheerio';
+
+const DEFAULT_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'Accept-Language': 'en-US,en;q=0.9',
+};
+
+const SECURITY_HEADERS = [
+  'strict-transport-security',
+  'content-security-policy',
+  'x-content-type-options',
+  'x-frame-options',
+  'referrer-policy',
+];
+
+const FRAMEWORK_ROOT_RE = /^(app|root|__next|__nuxt)$/i;
+
+/**
+ * Fetch a page and return structured analysis data.
+ *
+ * @param {string} url
+ * @param {{ timeout?: number, fetchFn?: Function }} options
+ * @returns {Promise<object>}
+ */
+export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
+  const result = {
+    url,
+    status_code: null,
+    redirect_chain: [],
+    headers: {},
+    title: null,
+    description: null,
+    canonical: null,
+    h1_tags: [],
+    heading_structure: [],
+    word_count: 0,
+    text_content: '',
+    internal_links: [],
+    external_links: [],
+    images: [],
+    structured_data: [],
+    has_ssr_content: true,
+    security_headers: {},
+    errors: [],
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout * 1000);
+
+  try {
+    const response = await fetchFn(url, {
+      headers: DEFAULT_HEADERS,
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+
+    result.status_code = response.status;
+
+    // Collect response headers
+    const rawHeaders = {};
+    response.headers.forEach((value, key) => {
+      rawHeaders[key] = value;
+    });
+    result.headers = rawHeaders;
+
+    // Security headers
+    for (const h of SECURITY_HEADERS) {
+      if (rawHeaders[h]) result.security_headers[h] = rawHeaders[h];
+    }
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+
+    // Basic metadata
+    result.title = $('title').first().text().trim() || null;
+    result.description =
+      $('meta[name="description"]').attr('content')?.trim() ||
+      $('meta[property="og:description"]').attr('content')?.trim() ||
+      null;
+    result.canonical =
+      $('link[rel="canonical"]').attr('href')?.trim() || null;
+
+    // Heading structure — must run BEFORE decompose()
+    $('h1, h2, h3, h4, h5, h6').each((_, el) => {
+      const tag = el.tagName.toLowerCase();
+      const text = $(el).text().trim();
+      result.heading_structure.push({ tag, text });
+      if (tag === 'h1') result.h1_tags.push(text);
+    });
+
+    // JSON-LD structured data — must run BEFORE decompose()
+    $('script[type="application/ld+json"]').each((_, el) => {
+      try {
+        const data = JSON.parse($(el).html());
+        result.structured_data.push(data);
+      } catch {
+        result.errors.push('Invalid JSON-LD detected');
+      }
+    });
+
+    // SSR check — MUST run BEFORE decompose() mutates the tree
+    // Issue #19: dual-condition guard prevents false positives on
+    // WordPress/Bricks/LiteSpeed sites that use framework-style root divs
+    // but serve full server-rendered HTML.
+    const ssrCheckResults = [];
+    $('[id]').each((_, el) => {
+      const id = $(el).attr('id') || '';
+      if (FRAMEWORK_ROOT_RE.test(id)) {
+        const innerText = $(el).text().trim();
+        ssrCheckResults.push({ id, text_length: innerText.length });
+      }
+    });
+
+    // Links — must run BEFORE decompose()
+    const parsedUrl = new URL(url);
+    const baseDomain = parsedUrl.hostname;
+    $('a[href]').each((_, el) => {
+      const href = $(el).attr('href');
+      if (!href || href.startsWith('#') || href.startsWith('javascript:')) return;
+      try {
+        const abs = new URL(href, url).href;
+        const parsed = new URL(abs);
+        const linkText = $(el).text().trim();
+        if (parsed.hostname === baseDomain) {
+          result.internal_links.push({ url: abs, text: linkText });
+        } else if (['http:', 'https:'].includes(parsed.protocol)) {
+          result.external_links.push({ url: abs, text: linkText });
+        }
+      } catch {
+        // malformed href — skip
+      }
+    });
+
+    // Images — must run BEFORE decompose()
+    $('img').each((_, el) => {
+      result.images.push({
+        src: $(el).attr('src') || '',
+        alt: $(el).attr('alt') || '',
+        width: $(el).attr('width') || null,
+        height: $(el).attr('height') || null,
+        loading: $(el).attr('loading') || null,
+      });
+    });
+
+    // Text content — decompose non-content elements (destructive)
+    $('script, style, nav, footer, header').each((_, el) => $(el).remove());
+    const text = $.root().text().replace(/\s+/g, ' ').trim();
+    result.text_content = text;
+    result.word_count = text ? text.split(/\s+/).length : 0;
+
+    // SSR assessment — uses pre-decompose measurements + final word count
+    // Only flag CSR when BOTH conditions hold:
+    //   1. Framework root div has < 50 chars of inner text
+    //   2. Overall page word count is < 200
+    // This prevents false positives on SSR sites (WordPress, LiteSpeed, Next.js SSR)
+    // that happen to use <div id="app"> or <div id="root"> as their mount point.
+    for (const check of ssrCheckResults) {
+      if (check.text_length < 50 && result.word_count < 200) {
+        result.has_ssr_content = false;
+        result.errors.push(
+          `Possible client-side only rendering detected: ` +
+            `#${check.id} has minimal server-rendered content ` +
+            `(${result.word_count} words on page)`
+        );
+      }
+    }
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      result.errors.push(`Timeout after ${timeout} seconds`);
+    } else if (err.cause?.code === 'ECONNREFUSED' || err.cause?.code === 'ENOTFOUND') {
+      result.errors.push(`Connection error: ${err.message}`);
+    } else {
+      result.errors.push(`Unexpected error: ${err.message}`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return result;
+}
+
+// CLI entrypoint
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const args = process.argv.slice(2);
+  const urlIdx = args.indexOf('--url');
+  const timeoutIdx = args.indexOf('--timeout');
+
+  if (urlIdx === -1 || !args[urlIdx + 1]) {
+    process.stderr.write('Usage: node scripts/fetch-page.mjs --url <url> [--timeout <seconds>]\n');
+    process.exit(1);
+  }
+
+  const url = args[urlIdx + 1];
+  const timeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1], 10) : 30;
+
+  fetchPage(url, { timeout })
+    .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))
+    .catch((err) => {
+      process.stderr.write(`Fatal: ${err.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -54,6 +54,7 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
     heading_structure: [],
     word_count: 0,
     text_content: '',
+    html: '',
     internal_links: [],
     external_links: [],
     images: [],
@@ -116,6 +117,7 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
     }
 
     const html = await response.text();
+    result.html = html;
     const $ = cheerio.load(html);
 
     // Basic metadata
@@ -158,14 +160,15 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
       }
     });
 
-    // Links — must run BEFORE decompose()
-    const parsedUrl = new URL(url);
+    // Use the final URL after redirect chain for link resolution and classification
+    const effectiveUrl = currentUrl;
+    const parsedUrl = new URL(effectiveUrl);
     const baseDomain = parsedUrl.hostname;
     $('a[href]').each((_, el) => {
       const href = $(el).attr('href');
       if (!href || href.startsWith('#') || href.startsWith('javascript:')) return;
       try {
-        const abs = new URL(href, url).href;
+        const abs = new URL(href, effectiveUrl).href;
         const parsed = new URL(abs);
         const linkText = $(el).text().trim();
         if (parsed.hostname === baseDomain) {

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -90,7 +90,10 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
         const nextUrl = new URL(location, currentUrl).toString();
         result.redirect_chain.push({ url: currentUrl, from: currentUrl, to: nextUrl, status });
         currentUrl = nextUrl;
-        if (i === MAX_REDIRECTS - 1) redirectLimitExceeded = true;
+        if (i === MAX_REDIRECTS - 1) {
+        redirectLimitExceeded = true;
+        break; // Don't process the redirect response as page content
+      }
         continue;
       }
       break;

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -91,9 +91,9 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
         result.redirect_chain.push({ url: currentUrl, from: currentUrl, to: nextUrl, status });
         currentUrl = nextUrl;
         if (i === MAX_REDIRECTS - 1) {
-        redirectLimitExceeded = true;
-        break; // Don't process the redirect response as page content
-      }
+          redirectLimitExceeded = true;
+          break; // Stop here — do not fall through to parse a 3xx as page content
+        }
         continue;
       }
       break;
@@ -102,9 +102,9 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     if (!response) throw new Error('No response received');
     if (redirectLimitExceeded) {
       result.errors.push('Too many redirects');
-    }
-
-    result.status_code = response.status;
+      result.status_code = response.status;
+      // Skip HTML parsing — response is a redirect, not page content
+    } else {
 
     // Collect response headers
     const rawHeaders = {};
@@ -227,6 +227,7 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
         );
       }
     }
+    } // end else (not redirectLimitExceeded)
   } catch (err) {
     if (err.name === 'AbortError') {
       result.errors.push(`Timeout after ${timeout} seconds`);

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -70,10 +70,12 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     // Manually follow redirects to populate redirect_chain
     const MAX_REDIRECTS = 10;
     let currentUrl = url;
+    let lastRequestedUrl = url; // tracks the URL we actually sent a request to
     let response;
     let redirectLimitExceeded = false;
 
     for (let i = 0; i < MAX_REDIRECTS; i++) {
+      lastRequestedUrl = currentUrl;
       response = await fetchFn(currentUrl, {
         headers: DEFAULT_HEADERS,
         redirect: 'manual',
@@ -103,7 +105,9 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     if (redirectLimitExceeded) {
       result.errors.push('Too many redirects');
       result.status_code = response.status;
-      result.url = currentUrl;
+      // Use lastRequestedUrl (the URL we actually fetched), not currentUrl
+      // which was already updated to the unfetched redirect target
+      result.url = lastRequestedUrl;
       // Skip HTML parsing — response is a redirect, not page content
     } else {
     // Record effective URL and status after following redirects

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -186,15 +186,18 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     // Use the final URL after redirect chain for link resolution and classification
     const effectiveUrl = currentUrl;
     const parsedUrl = new URL(effectiveUrl);
-    const baseDomain = parsedUrl.hostname;
+    const baseDomain = parsedUrl.host;
     $('a[href]').each((_, el) => {
-      const href = $(el).attr('href');
+      const $el = $(el);
+      const href = $el.attr('href');
       if (!href || href.startsWith('#') || href.startsWith('javascript:')) return;
+      // Skip links inside nav/header/footer to match Python decompose() parity
+      if ($el.closest('nav, header, footer').length) return;
       try {
         const abs = new URL(href, effectiveUrl).href;
         const parsed = new URL(abs);
-        const linkText = $(el).text().trim();
-        if (parsed.hostname === baseDomain) {
+        const linkText = $el.text().trim();
+        if (parsed.host === baseDomain) {
           result.internal_links.push({ url: abs, text: linkText });
         } else if (['http:', 'https:'].includes(parsed.protocol)) {
           result.external_links.push({ url: abs, text: linkText });

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -9,9 +9,11 @@
  * - SSR detection (Issue #19: dual-condition guard prevents false positives)
  *
  * Usage: node scripts/fetch-page.mjs --url <url> [--timeout <seconds>]
- * Output: JSON to stdout. Errors to stderr, exit code 1.
+ *        node scripts/fetch-page.mjs --help
+ * Output: JSON to stdout (including on fatal error). Errors also to stderr, exit code 1.
  */
 
+import { fileURLToPath } from 'node:url';
 import * as cheerio from 'cheerio';
 
 const DEFAULT_HEADERS = {
@@ -27,6 +29,7 @@ const SECURITY_HEADERS = [
   'x-content-type-options',
   'x-frame-options',
   'referrer-policy',
+  'permissions-policy',
 ];
 
 const FRAMEWORK_ROOT_RE = /(app|root|__next|__nuxt)/i;
@@ -68,6 +71,7 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
     const MAX_REDIRECTS = 10;
     let currentUrl = url;
     let response;
+    let redirectLimitExceeded = false;
 
     for (let i = 0; i < MAX_REDIRECTS; i++) {
       response = await fetchFn(currentUrl, {
@@ -79,17 +83,21 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
       const status = response.status;
       if (status >= 300 && status < 400) {
         const location = response.headers.get('location');
-        if (!location) break;
+        if (!location) {
+          result.errors.push(`Redirect response (${status}) missing Location header at ${currentUrl}`);
+          break;
+        }
         const nextUrl = new URL(location, currentUrl).toString();
         result.redirect_chain.push({ url: nextUrl, status });
         currentUrl = nextUrl;
+        if (i === MAX_REDIRECTS - 1) redirectLimitExceeded = true;
         continue;
       }
       break;
     }
 
     if (!response) throw new Error('No response received');
-    if (response.status >= 300 && response.status < 400) {
+    if (redirectLimitExceeded) {
       result.errors.push('Too many redirects');
     }
 
@@ -191,8 +199,6 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
     // Only flag CSR when BOTH conditions hold:
     //   1. Framework root div has < 50 chars of inner text
     //   2. Overall page word count is < 200
-    // This prevents false positives on SSR sites (WordPress, LiteSpeed, Next.js SSR)
-    // that happen to use <div id="app"> or <div id="root"> as their mount point.
     for (const check of ssrCheckResults) {
       if (check.text_length < 50 && result.word_count < 200) {
         result.has_ssr_content = false;
@@ -219,13 +225,28 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
 }
 
 // CLI entrypoint
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
+
+  if (args.includes('--help')) {
+    process.stdout.write(
+      'Usage: node scripts/fetch-page.mjs --url <url> [--timeout <seconds>]\n\n' +
+      'Options:\n' +
+      '  --url <url>         URL to fetch (required)\n' +
+      '  --timeout <seconds> Request timeout in seconds (default: 30)\n' +
+      '  --help              Show this help message\n\n' +
+      'Output: JSON to stdout. On error, JSON error object to stdout + message to stderr.\n'
+    );
+    process.exit(0);
+  }
+
   const urlIdx = args.indexOf('--url');
   const timeoutIdx = args.indexOf('--timeout');
 
   if (urlIdx === -1 || !args[urlIdx + 1]) {
-    process.stderr.write('Usage: node scripts/fetch-page.mjs --url <url> [--timeout <seconds>]\n');
+    process.stderr.write('Error: --url is required\n');
+    process.stderr.write('Run with --help for usage.\n');
+    process.stdout.write(JSON.stringify({ error: '--url is required' }) + '\n');
     process.exit(1);
   }
 
@@ -242,7 +263,13 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   fetchPage(url, { timeout })
     .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))
     .catch((err) => {
-      process.stderr.write(`Fatal: ${err.message}\n`);
+      const msg = err?.message ?? 'Unknown error';
+      process.stderr.write(`Fatal: ${msg}\n`);
+      try {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } catch {
+        process.stdout.write('{"error":"Unknown error"}\n');
+      }
       process.exit(1);
     });
 }

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -41,7 +41,7 @@ const FRAMEWORK_ROOT_RE = /(app|root|__next|__nuxt)/i;
  * @param {{ timeout?: number, fetchFn?: Function }} options
  * @returns {Promise<object>}
  */
-export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
+export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtml = false } = {}) {
   const result = {
     url,
     status_code: null,
@@ -54,7 +54,6 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
     heading_structure: [],
     word_count: 0,
     text_content: '',
-    html: '',
     internal_links: [],
     external_links: [],
     images: [],
@@ -117,7 +116,9 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch } = {}) {
     }
 
     const html = await response.text();
-    result.html = html;
+    // Only include raw HTML in output when explicitly requested (opt-in)
+    // to keep default stdout output lightweight
+    if (includeHtml) result.html = html;
     const $ = cheerio.load(html);
 
     // Basic metadata

--- a/scripts/fetch-page.mjs
+++ b/scripts/fetch-page.mjs
@@ -38,7 +38,7 @@ const FRAMEWORK_ROOT_RE = /(app|root|__next|__nuxt)/i;
  * Fetch a page and return structured analysis data.
  *
  * @param {string} url
- * @param {{ timeout?: number, fetchFn?: Function }} options
+ * @param {{ timeout?: number, fetchFn?: Function, includeHtml?: boolean }} options
  * @returns {Promise<object>}
  */
 export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtml = false } = {}) {
@@ -88,7 +88,7 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
           break;
         }
         const nextUrl = new URL(location, currentUrl).toString();
-        result.redirect_chain.push({ url: nextUrl, status });
+        result.redirect_chain.push({ url: currentUrl, from: currentUrl, to: nextUrl, status });
         currentUrl = nextUrl;
         if (i === MAX_REDIRECTS - 1) redirectLimitExceeded = true;
         continue;
@@ -133,8 +133,9 @@ export async function fetchPage(url, { timeout = 30, fetchFn = fetch, includeHtm
     // Heading structure — must run BEFORE decompose()
     $('h1, h2, h3, h4, h5, h6').each((_, el) => {
       const tag = el.tagName.toLowerCase();
+      const level = parseInt(tag.slice(1), 10);
       const text = $(el).text().trim();
-      result.heading_structure.push({ tag, text });
+      result.heading_structure.push({ tag, level, text });
       if (tag === 'h1') result.h1_tags.push(text);
     });
 

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -193,9 +193,9 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
     Support: [],
   };
 
-  // Initialize seen with just the base URL (not base+'/' duplicate)
-  // so pages_analyzed accurately reflects discovered URLs
-  const seen = new Set([base]);
+  // Seed seen with both normalized forms of the root URL to avoid
+  // counting base and base+'/' as separate discovered URLs
+  const seen = new Set([base, base + '/']);
   const SKIP_EXTS = /\.(pdf|jpg|jpeg|png|gif|svg|webp|css|js|ico|xml|json)$/i;
 
   $('a[href]').each((_, el) => {

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -61,7 +61,7 @@ export async function validateLlmstxt(url, { fetchFn = fetch } = {}) {
       const content = await res.text();
       result.content = content;
 
-      const lines = content.trim().split('\n');
+      const lines = content.trim().split(/\r?\n/);
 
       if (lines[0]?.startsWith('# ')) {
         result.has_title = true;
@@ -159,6 +159,14 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
   let homepageHtml = '';
   try {
     const res = await fetchFn(`${base}/`, { headers: DEFAULT_HEADERS });
+    if (!(res.ok ?? (res.status >= 200 && res.status < 300))) {
+      const statusText = res.statusText || '';
+      result.issues.push(
+        `Failed to fetch homepage: HTTP ${res.status}${statusText ? ` ${statusText}` : ''}`,
+      );
+      result.status = 'error';
+      return result;
+    }
     homepageHtml = await res.text();
   } catch (err) {
     result.issues.push(`Failed to fetch homepage: ${err.message}`);

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -1,0 +1,305 @@
+/**
+ * llmstxt-generator.mjs — llms.txt validator and generator
+ *
+ * Validates an existing /llms.txt file or generates a new one by crawling
+ * the site homepage and sitemap.
+ *
+ * Usage:
+ *   node scripts/llmstxt-generator.mjs --url <url> --mode validate
+ *   node scripts/llmstxt-generator.mjs --url <url> --mode generate
+ *
+ * Output: JSON to stdout. Errors to stderr, exit code 1.
+ */
+
+import * as cheerio from 'cheerio';
+
+const DEFAULT_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+};
+
+// ---------------------------------------------------------------------------
+// Validate an existing llms.txt
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url - any URL on the domain
+ * @param {{ fetchFn?: Function }} options
+ * @returns {Promise<object>}
+ */
+export async function validateLlmstxt(url, { fetchFn = fetch } = {}) {
+  const base = getBase(url);
+  const llmsUrl = `${base}/llms.txt`;
+  const llmsFullUrl = `${base}/llms-full.txt`;
+
+  const result = {
+    url: llmsUrl,
+    status: 'not_found',
+    score: 0,
+    exists: false,
+    format_valid: false,
+    has_title: false,
+    has_description: false,
+    has_sections: false,
+    has_links: false,
+    section_count: 0,
+    link_count: 0,
+    content: '',
+    issues: [],
+    suggestions: [],
+    full_version: { url: llmsFullUrl, exists: false },
+  };
+
+  try {
+    const res = await fetchFn(llmsUrl, { headers: DEFAULT_HEADERS });
+    if (res.status === 200) {
+      result.exists = true;
+      result.status = 'found';
+      const content = await res.text();
+      result.content = content;
+
+      const lines = content.trim().split('\n');
+
+      if (lines[0]?.startsWith('# ')) {
+        result.has_title = true;
+      } else {
+        result.issues.push("Missing title — first line must be '# Site Name'");
+      }
+
+      if (lines.some((l) => l.startsWith('> '))) {
+        result.has_description = true;
+      } else {
+        result.issues.push("Missing description — add '> Brief description' after title");
+      }
+
+      const sections = lines.filter((l) => l.startsWith('## '));
+      result.section_count = sections.length;
+      result.has_sections = sections.length > 0;
+      if (!result.has_sections) {
+        result.issues.push("No sections — add '## Section Name' headings");
+      }
+
+      const linkMatches = content.match(/^- \[.+\]\(.+\)/gm) || [];
+      result.link_count = linkMatches.length;
+      result.has_links = linkMatches.length > 0;
+      if (!result.has_links) {
+        result.issues.push("No page links — add '- [Page Title](url): Description' entries");
+      }
+
+      result.format_valid =
+        result.has_title && result.has_description && result.has_sections && result.has_links;
+
+      if (result.link_count < 5)
+        result.suggestions.push('Add more key page entries (aim for 10-20)');
+      if (result.section_count < 2)
+        result.suggestions.push('Add more sections to organise content types');
+      if (!/contact/i.test(content))
+        result.suggestions.push('Add a Contact section with email and website');
+      if (!/key fact/i.test(content) && !/about/i.test(content))
+        result.suggestions.push('Add Key Facts section with founding date, location, core services');
+
+      result.score = _scoreValidation(result);
+    } else {
+      result.issues.push(`llms.txt returned HTTP ${res.status}`);
+    }
+  } catch (err) {
+    result.issues.push(`Error fetching llms.txt: ${err.message}`);
+    result.status = 'error';
+  }
+
+  // Check llms-full.txt
+  try {
+    const fullRes = await fetchFn(llmsFullUrl, { headers: DEFAULT_HEADERS });
+    if (fullRes.status === 200) result.full_version.exists = true;
+  } catch {
+    // not present — that's fine
+  }
+
+  return result;
+}
+
+function _scoreValidation(r) {
+  let completeness = 0;
+  if (r.has_title) completeness += 20;
+  if (r.has_description) completeness += 20;
+  if (r.has_sections) completeness += 20;
+  if (r.link_count >= 5) completeness += 20;
+  if (r.link_count >= 10) completeness += 10;
+  if (r.full_version?.exists) completeness += 10;
+
+  // Clamp to 100
+  return Math.min(completeness, 100);
+}
+
+// ---------------------------------------------------------------------------
+// Generate a new llms.txt from site crawl
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url
+ * @param {{ fetchFn?: Function, maxPages?: number }} options
+ * @returns {Promise<object>}
+ */
+export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = {}) {
+  const base = getBase(url);
+  const result = {
+    status: 'generated',
+    pages_analyzed: 0,
+    sections: {},
+    generated: '',
+    issues: [],
+  };
+
+  let homepageHtml = '';
+  try {
+    const res = await fetchFn(url, { headers: DEFAULT_HEADERS });
+    homepageHtml = await res.text();
+  } catch (err) {
+    result.issues.push(`Failed to fetch homepage: ${err.message}`);
+    result.status = 'error';
+    return result;
+  }
+
+  const $ = cheerio.load(homepageHtml);
+
+  // Site identity
+  const rawTitle = $('title').first().text().trim();
+  const siteName = rawTitle.split(/[|\-–]/)[0].trim() || new URL(base).hostname;
+  const siteDescription =
+    $('meta[name="description"]').attr('content')?.trim() ||
+    $('meta[property="og:description"]').attr('content')?.trim() ||
+    `Official website of ${siteName}`;
+
+  // Discover and categorise internal pages
+  const pages = {
+    'Main Pages': [],
+    'Products & Services': [],
+    'Resources & Blog': [],
+    Company: [],
+    Support: [],
+  };
+
+  const seen = new Set([base + '/', base]);
+  const SKIP_EXTS = /\.(pdf|jpg|jpeg|png|gif|svg|webp|css|js|ico|xml|json)$/i;
+
+  $('a[href]').each((_, el) => {
+    if (seen.size >= maxPages) return false;
+    const href = $(el).attr('href');
+    if (!href || href.startsWith('#') || href.startsWith('javascript:')) return;
+    let abs;
+    try {
+      abs = new URL(href, base).href.split('#')[0];
+    } catch {
+      return;
+    }
+    const parsed = new URL(abs);
+    if (parsed.hostname !== new URL(base).hostname) return;
+    if (SKIP_EXTS.test(parsed.pathname)) return;
+    if (seen.has(abs)) return;
+    seen.add(abs);
+
+    const text = $(el).text().trim();
+    if (!text || text.length < 2) return;
+
+    const path = parsed.pathname.toLowerCase();
+    const entry = { url: abs, title: text };
+
+    if (/\/(pricing|feature|product|solution|demo)/.test(path))
+      pages['Products & Services'].push(entry);
+    else if (/\/(blog|article|resource|guide|learn|docs|documentation)/.test(path))
+      pages['Resources & Blog'].push(entry);
+    else if (/\/(about|team|career|contact|press|partner)/.test(path))
+      pages['Company'].push(entry);
+    else if (/\/(help|support|faq|status)/.test(path))
+      pages['Support'].push(entry);
+    else pages['Main Pages'].push(entry);
+  });
+
+  result.pages_analyzed = seen.size;
+  result.sections = Object.fromEntries(Object.entries(pages).map(([k, v]) => [k, v.length]));
+
+  // Build llms.txt content
+  const lines = [`# ${siteName}`, `> ${siteDescription}`, ''];
+
+  // Always include homepage first
+  lines.push('## Main Pages');
+  lines.push(`- [Home](${base}/): Homepage of ${siteName}.`);
+  for (const p of pages['Main Pages'].slice(0, 8)) {
+    lines.push(`- [${p.title}](${p.url})`);
+  }
+  lines.push('');
+
+  for (const [section, sectionPages] of Object.entries(pages)) {
+    if (section === 'Main Pages' || sectionPages.length === 0) continue;
+    lines.push(`## ${section}`);
+    for (const p of sectionPages.slice(0, 10)) {
+      lines.push(`- [${p.title}](${p.url})`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Contact');
+  lines.push(`- Website: ${base}`);
+  lines.push(`- Email: contact@${new URL(base).hostname}`);
+  lines.push('');
+
+  result.generated = lines.join('\n');
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Combined entry point (validate → generate if not found)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url
+ * @param {'validate'|'generate'} mode
+ * @param {{ fetchFn?: Function }} options
+ * @returns {Promise<object>}
+ */
+export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {}) {
+  if (mode === 'validate') {
+    const validation = await validateLlmstxt(url, { fetchFn });
+    // If not found, also generate so the caller gets a ready-to-use file
+    if (!validation.exists) {
+      const generated = await generateLlmstxt(url, { fetchFn });
+      return { ...validation, ...generated, status: 'not_found' };
+    }
+    return validation;
+  }
+  return generateLlmstxt(url, { fetchFn });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getBase(url) {
+  const parsed = new URL(url.startsWith('http') ? url : `https://${url}`);
+  return `${parsed.protocol}//${parsed.hostname}`;
+}
+
+// CLI entrypoint
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const args = process.argv.slice(2);
+  const urlIdx = args.indexOf('--url');
+  const modeIdx = args.indexOf('--mode');
+
+  if (urlIdx === -1 || !args[urlIdx + 1]) {
+    process.stderr.write(
+      'Usage: node scripts/llmstxt-generator.mjs --url <url> --mode validate|generate\n'
+    );
+    process.exit(1);
+  }
+
+  const url = args[urlIdx + 1];
+  const mode = modeIdx !== -1 ? args[modeIdx + 1] : 'validate';
+
+  runLlmstxt(url, mode)
+    .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))
+    .catch((err) => {
+      process.stderr.write(`Fatal: ${err.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -232,6 +232,7 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
   });
 
   result.pages_analyzed = seen.size;
+  result.urls_discovered = seen.size; // Alias: links found via <a> tags (not all fetched)
   result.sections = Object.fromEntries(Object.entries(pages).map(([k, v]) => [k, v.length]));
 
   // Build llms.txt content

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -153,7 +153,7 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
 
   let homepageHtml = '';
   try {
-    const res = await fetchFn(url, { headers: DEFAULT_HEADERS });
+    const res = await fetchFn(`${base}/`, { headers: DEFAULT_HEADERS });
     homepageHtml = await res.text();
   } catch (err) {
     result.issues.push(`Failed to fetch homepage: ${err.message}`);

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -185,7 +185,9 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
     Support: [],
   };
 
-  const seen = new Set([base + '/', base]);
+  // Initialize seen with just the base URL (not base+'/' duplicate)
+  // so pages_analyzed accurately reflects discovered URLs
+  const seen = new Set([base]);
   const SKIP_EXTS = /\.(pdf|jpg|jpeg|png|gif|svg|webp|css|js|ico|xml|json)$/i;
 
   $('a[href]').each((_, el) => {
@@ -274,24 +276,26 @@ export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {
 
   if (mode === 'validate') {
     const validation = await validateLlmstxt(url, { fetchFn });
-    if (!validation.exists) {
-      const generated = await generateLlmstxt(url, { fetchFn });
-      // Merge issues/suggestions intentionally — don't overwrite validation reason
-      return {
-        ...validation,
-        ...generated,
-        issues: [
-          ...(Array.isArray(validation.issues) ? validation.issues : []),
-          ...(Array.isArray(generated.issues) ? generated.issues : []),
-        ],
-        suggestions: [
-          ...(Array.isArray(validation.suggestions) ? validation.suggestions : []),
-          ...(Array.isArray(generated.suggestions) ? generated.suggestions : []),
-        ],
-        status: 'not_found',
-      };
+    // Only fall back to generate on true not-found (404/DNS miss).
+    // Preserve http_error/error statuses — don't generate on 403/500.
+    if (validation.status !== 'not_found') {
+      return validation;
     }
-    return validation;
+    const generated = await generateLlmstxt(url, { fetchFn });
+    // Merge issues/suggestions intentionally — don't overwrite validation reason
+    return {
+      ...validation,
+      ...generated,
+      issues: [
+        ...(Array.isArray(validation.issues) ? validation.issues : []),
+        ...(Array.isArray(generated.issues) ? generated.issues : []),
+      ],
+      suggestions: [
+        ...(Array.isArray(validation.suggestions) ? validation.suggestions : []),
+        ...(Array.isArray(generated.suggestions) ? generated.suggestions : []),
+      ],
+      status: 'not_found',
+    };
   }
   return generateLlmstxt(url, { fetchFn });
 }

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -7,10 +7,12 @@
  * Usage:
  *   node scripts/llmstxt-generator.mjs --url <url> --mode validate
  *   node scripts/llmstxt-generator.mjs --url <url> --mode generate
+ *   node scripts/llmstxt-generator.mjs --help
  *
- * Output: JSON to stdout. Errors to stderr, exit code 1.
+ * Output: JSON to stdout (including on fatal error). Errors also to stderr, exit code 1.
  */
 
+import { fileURLToPath } from 'node:url';
 import * as cheerio from 'cheerio';
 
 const DEFAULT_HEADERS = {
@@ -102,6 +104,8 @@ export async function validateLlmstxt(url, { fetchFn = fetch } = {}) {
       result.score = _scoreValidation(result);
     } else {
       result.issues.push(`llms.txt returned HTTP ${res.status}`);
+      // Distinguish HTTP errors from true 404/not-found
+      if (res.status !== 404) result.status = 'http_error';
     }
   } catch (err) {
     result.issues.push(`Error fetching llms.txt: ${err.message}`);
@@ -149,6 +153,7 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
     sections: {},
     generated: '',
     issues: [],
+    suggestions: [],
   };
 
   let homepageHtml = '';
@@ -222,7 +227,6 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
   // Build llms.txt content
   const lines = [`# ${siteName}`, `> ${siteDescription}`, ''];
 
-  // Always include homepage first
   lines.push('## Main Pages');
   lines.push(`- [Home](${base}/): Homepage of ${siteName}.`);
   for (const p of pages['Main Pages'].slice(0, 8)) {
@@ -261,10 +265,22 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
 export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {}) {
   if (mode === 'validate') {
     const validation = await validateLlmstxt(url, { fetchFn });
-    // If not found, also generate so the caller gets a ready-to-use file
     if (!validation.exists) {
       const generated = await generateLlmstxt(url, { fetchFn });
-      return { ...validation, ...generated, status: 'not_found' };
+      // Merge issues/suggestions intentionally — don't overwrite validation reason
+      return {
+        ...validation,
+        ...generated,
+        issues: [
+          ...(Array.isArray(validation.issues) ? validation.issues : []),
+          ...(Array.isArray(generated.issues) ? generated.issues : []),
+        ],
+        suggestions: [
+          ...(Array.isArray(validation.suggestions) ? validation.suggestions : []),
+          ...(Array.isArray(generated.suggestions) ? generated.suggestions : []),
+        ],
+        status: 'not_found',
+      };
     }
     return validation;
   }
@@ -277,19 +293,33 @@ export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {
 
 function getBase(url) {
   const parsed = new URL(url.startsWith('http') ? url : `https://${url}`);
-  return `${parsed.protocol}//${parsed.hostname}`;
+  // Use host (hostname + port) to preserve explicit ports (e.g., localhost:3000)
+  return `${parsed.protocol}//${parsed.host}`;
 }
 
 // CLI entrypoint
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
+
+  if (args.includes('--help')) {
+    process.stdout.write(
+      'Usage: node scripts/llmstxt-generator.mjs --url <url> [--mode validate|generate]\n\n' +
+      'Options:\n' +
+      '  --url <url>              URL to analyse (required)\n' +
+      '  --mode validate|generate Mode of operation (default: validate)\n' +
+      '  --help                   Show this help message\n\n' +
+      'Output: JSON to stdout. On error, JSON error object to stdout + message to stderr.\n'
+    );
+    process.exit(0);
+  }
+
   const urlIdx = args.indexOf('--url');
   const modeIdx = args.indexOf('--mode');
 
   if (urlIdx === -1 || !args[urlIdx + 1]) {
-    process.stderr.write(
-      'Usage: node scripts/llmstxt-generator.mjs --url <url> --mode validate|generate\n'
-    );
+    process.stderr.write('Error: --url is required\n');
+    process.stderr.write('Run with --help for usage.\n');
+    process.stdout.write(JSON.stringify({ error: '--url is required' }) + '\n');
     process.exit(1);
   }
 
@@ -299,7 +329,13 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   runLlmstxt(url, mode)
     .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))
     .catch((err) => {
-      process.stderr.write(`Fatal: ${err.message}\n`);
+      const msg = err?.message ?? 'Unknown error';
+      process.stderr.write(`Fatal: ${msg}\n`);
+      try {
+        process.stdout.write(JSON.stringify({ error: msg }) + '\n');
+      } catch {
+        process.stdout.write('{"error":"Unknown error"}\n');
+      }
       process.exit(1);
     });
 }

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -303,7 +303,8 @@ export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {
         ...(Array.isArray(validation.suggestions) ? validation.suggestions : []),
         ...(Array.isArray(generated.suggestions) ? generated.suggestions : []),
       ],
-      status: 'not_found',
+      // Preserve generation failure status; don't mask 'error' as 'not_found'
+      status: generated.status === 'error' ? 'error' : 'not_found',
     };
   }
   return generateLlmstxt(url, { fetchFn });

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -2,7 +2,7 @@
  * llmstxt-generator.mjs — llms.txt validator and generator
  *
  * Validates an existing /llms.txt file or generates a new one by crawling
- * the site homepage and sitemap.
+ * the site starting from the homepage.
  *
  * Usage:
  *   node scripts/llmstxt-generator.mjs --url <url> --mode validate
@@ -263,6 +263,15 @@ export async function generateLlmstxt(url, { fetchFn = fetch, maxPages = 30 } = 
  * @returns {Promise<object>}
  */
 export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {}) {
+  const VALID_MODES = ['validate', 'generate'];
+  if (!VALID_MODES.includes(mode)) {
+    return {
+      status: 'error',
+      issues: [`Unknown mode '${mode}' — valid modes are: ${VALID_MODES.join(', ')}`],
+      generated: '',
+    };
+  }
+
   if (mode === 'validate') {
     const validation = await validateLlmstxt(url, { fetchFn });
     if (!validation.exists) {

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -314,7 +314,8 @@ export async function runLlmstxt(url, mode = 'validate', { fetchFn = fetch } = {
 // ---------------------------------------------------------------------------
 
 function getBase(url) {
-  const parsed = new URL(url.startsWith('http') ? url : `https://${url}`);
+  const normalized = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+  const parsed = new URL(normalized);
   // Use host (hostname + port) to preserve explicit ports (e.g., localhost:3000)
   return `${parsed.protocol}//${parsed.host}`;
 }

--- a/scripts/llmstxt-generator.mjs
+++ b/scripts/llmstxt-generator.mjs
@@ -346,7 +346,17 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 
   const url = args[urlIdx + 1];
-  const mode = modeIdx !== -1 ? args[modeIdx + 1] : 'validate';
+  let mode = 'validate';
+  if (modeIdx !== -1) {
+    const modeArg = args[modeIdx + 1];
+    if (!modeArg || modeArg.startsWith('--')) {
+      process.stderr.write('Error: --mode value is required\n');
+      process.stderr.write('Run with --help for usage.\n');
+      process.stdout.write(JSON.stringify({ error: '--mode value is required' }) + '\n');
+      process.exit(1);
+    }
+    mode = modeArg;
+  }
 
   runLlmstxt(url, mode)
     .then((result) => process.stdout.write(JSON.stringify(result, null, 2) + '\n'))

--- a/tests/citability-scorer.test.mjs
+++ b/tests/citability-scorer.test.mjs
@@ -1,0 +1,158 @@
+/**
+ * tests/citability-scorer.test.mjs
+ *
+ * Tests for citability-scorer.mjs scorePassage() function.
+ * Covers all 5 scoring dimensions and edge cases.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { scorePassage } from '../scripts/citability-scorer.mjs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const HIGH_CITABILITY = `Content delivery networks (CDNs) are distributed server systems that
+cache and serve web content from locations geographically close to end users.
+A CDN reduces latency by 50-70% on average according to Cloudflare research.
+The three largest CDN providers as of 2024 are Cloudflare (serving 20% of all
+websites), Amazon CloudFront, and Akamai Technologies. By distributing content
+across multiple edge nodes, CDNs improve page load times and reduce origin
+server load. Organizations using a CDN typically see 40% improvement in Time
+to First Byte (TTFB) and significant reductions in bandwidth costs. The
+technology was first commercialized in 1998 and has since become standard
+infrastructure for any site serving global audiences.`;
+
+const LOW_CITABILITY = `If you've ever wondered why some websites load faster than others,
+you might be surprised. It's amazing when you think about it. Many companies
+use this technology. A significant percentage of sites have adopted it.
+Studies show it helps. The technology has been around for a while now and
+it's really quite interesting. Some people think it's great.`;
+
+const DEFINITION_PATTERN = `Machine learning is a subset of artificial intelligence that enables
+systems to learn and improve from experience without being explicitly
+programmed. According to Stanford research, machine learning algorithms
+build mathematical models based on training data. There are three main
+types: supervised learning, unsupervised learning, and reinforcement learning.
+As of 2024, over 80% of Fortune 500 companies use machine learning in some
+capacity.`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('scorePassage — output contract', () => {
+  it('returns all required fields', () => {
+    const result = scorePassage('This is a test passage with enough words.', 'Test Heading');
+    const required = ['heading', 'word_count', 'total_score', 'grade', 'label', 'breakdown', 'preview'];
+    for (const field of required) {
+      assert.ok(Object.hasOwn(result, field), `Missing field: ${field}`);
+    }
+  });
+
+  it('breakdown contains all 5 scoring dimensions', () => {
+    const result = scorePassage('Some text here.');
+    const dims = ['answer_block_quality', 'self_containment', 'structural_readability', 'statistical_density', 'uniqueness_signals'];
+    for (const d of dims) {
+      assert.ok(Object.hasOwn(result.breakdown, d), `Missing dimension: ${d}`);
+    }
+  });
+
+  it('total_score is sum of breakdown values', () => {
+    const result = scorePassage(HIGH_CITABILITY);
+    const sum = Object.values(result.breakdown).reduce((a, b) => a + b, 0);
+    assert.strictEqual(result.total_score, sum);
+  });
+
+  it('scores are within their maximum bounds', () => {
+    const result = scorePassage(HIGH_CITABILITY);
+    assert.ok(result.breakdown.answer_block_quality <= 30);
+    assert.ok(result.breakdown.self_containment <= 25);
+    assert.ok(result.breakdown.structural_readability <= 20);
+    assert.ok(result.breakdown.statistical_density <= 15);
+    assert.ok(result.breakdown.uniqueness_signals <= 10);
+  });
+
+  it('total_score is between 0 and 100', () => {
+    const result = scorePassage(HIGH_CITABILITY);
+    assert.ok(result.total_score >= 0);
+    assert.ok(result.total_score <= 100);
+  });
+
+  it('word_count matches actual word count', () => {
+    const text = 'One two three four five six seven eight nine ten.';
+    const result = scorePassage(text);
+    assert.strictEqual(result.word_count, 10);
+  });
+
+  it('preview is truncated to 30 words with ellipsis', () => {
+    const words = Array.from({ length: 50 }, (_, i) => `word${i}`);
+    const result = scorePassage(words.join(' '));
+    assert.ok(result.preview.endsWith('...'));
+    // preview = "word0 word1 ... word29..." — 30 words, last one suffixed with '...'
+    assert.strictEqual(result.preview.split(' ').length, 30);
+  });
+});
+
+describe('scorePassage — grade assignment', () => {
+  it('high-quality passage gets grade A or B', () => {
+    const result = scorePassage(HIGH_CITABILITY);
+    assert.ok(['A', 'B'].includes(result.grade), `Expected A or B, got ${result.grade} (score: ${result.total_score})`);
+  });
+
+  it('low-quality passage gets grade D or F', () => {
+    const result = scorePassage(LOW_CITABILITY);
+    assert.ok(['D', 'F'].includes(result.grade), `Expected D or F, got ${result.grade} (score: ${result.total_score})`);
+  });
+
+  it('high passage scores higher than low passage', () => {
+    const high = scorePassage(HIGH_CITABILITY);
+    const low = scorePassage(LOW_CITABILITY);
+    assert.ok(high.total_score > low.total_score, `High: ${high.total_score}, Low: ${low.total_score}`);
+  });
+});
+
+describe('scorePassage — answer block quality', () => {
+  it('definition pattern ("X is a...") increases score', () => {
+    const withDef = scorePassage(DEFINITION_PATTERN);
+    const withoutDef = scorePassage(LOW_CITABILITY);
+    assert.ok(
+      withDef.breakdown.answer_block_quality > withoutDef.breakdown.answer_block_quality
+    );
+  });
+
+  it('question heading adds bonus points', () => {
+    const withQ = scorePassage('Machine learning is a method of data analysis. It automates analytical model building.', 'What is machine learning?');
+    const withoutQ = scorePassage('Machine learning is a method of data analysis. It automates analytical model building.', 'Machine Learning');
+    assert.ok(withQ.breakdown.answer_block_quality >= withoutQ.breakdown.answer_block_quality);
+  });
+});
+
+describe('scorePassage — self-containment', () => {
+  it('optimal word count (134-167) scores highest in self-containment', () => {
+    const optimalWords = Array.from({ length: 150 }, (_, i) => `word${i} Acme Corp value`).join(' ').split(' ').slice(0, 150).join(' ');
+    const result = scorePassage(optimalWords);
+    assert.ok(result.breakdown.self_containment >= 10, `Expected >=10, got ${result.breakdown.self_containment}`);
+  });
+
+  it('very short passage (< 30 words) scores 0 for word count component', () => {
+    const short = scorePassage('Short text here only few words.');
+    // Short text gets minimal self-containment
+    assert.ok(short.breakdown.self_containment < 15);
+  });
+});
+
+describe('scorePassage — statistical density', () => {
+  it('percentages increase statistical density score', () => {
+    const withPct = scorePassage('Performance improved by 45% and 67% with this approach in 2024.');
+    const withoutPct = scorePassage('Performance improved significantly and greatly with this approach.');
+    assert.ok(withPct.breakdown.statistical_density > withoutPct.breakdown.statistical_density);
+  });
+
+  it('named sources increase statistical density score', () => {
+    const withSource = scorePassage('According to Google research published in 2024, the approach yields results.');
+    const withoutSource = scorePassage('Research published recently shows the approach yields results.');
+    assert.ok(withSource.breakdown.statistical_density >= withoutSource.breakdown.statistical_density);
+  });
+});

--- a/tests/fetch-page.test.mjs
+++ b/tests/fetch-page.test.mjs
@@ -10,7 +10,7 @@
  * 8 test suites, 18 assertions — mirrors Python test class structure exactly.
  */
 
-import { describe, it, mock } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { fetchPage } from '../scripts/fetch-page.mjs';
 

--- a/tests/fetch-page.test.mjs
+++ b/tests/fetch-page.test.mjs
@@ -1,0 +1,358 @@
+/**
+ * tests/fetch-page.test.mjs
+ *
+ * Node.js test parity for tests/test_fetch_page_ssr.py
+ *
+ * Covers the fix for GitHub Issue #19: false positives where sites using
+ * framework-style root divs (id="app", id="root") but serving full HTML via
+ * SSR/prerendering were incorrectly flagged as client-side-only.
+ *
+ * 8 test suites, 18 assertions — mirrors Python test class structure exactly.
+ */
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchPage } from '../scripts/fetch-page.mjs';
+
+// ---------------------------------------------------------------------------
+// HTML Fixtures (mirrors Python test fixtures exactly)
+// ---------------------------------------------------------------------------
+
+const WORDPRESS_BRICKS_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Bricks Builder Site</title></head>
+<body>
+  <div id="app">
+    <header><nav>Home About Contact</nav></header>
+    <main>
+      <h1>Welcome to our WordPress site</h1>
+      <p>This is a fully server-rendered page built with Bricks Builder on
+      WordPress. All the content below is rendered by PHP on the server and
+      delivered as complete HTML to the browser and to any crawler or AI bot
+      that requests it without running JavaScript.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+      minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+      ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+      voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+      officia deserunt mollit anim id est laborum. Additional content here to
+      ensure we exceed the two-hundred word threshold used by the heuristic
+      so that this page is correctly recognised as server-rendered content
+      rather than a blank client-side shell waiting for JavaScript to hydrate
+      it.</p>
+    </main>
+    <footer>Footer content here</footer>
+  </div>
+</body>
+</html>`;
+
+const LITESPEED_CACHE_HTML = `<!DOCTYPE html>
+<html>
+<head><title>LiteSpeed Cache Site</title></head>
+<body>
+  <div id="root">
+    <h1>Product catalogue</h1>
+    <p>Our products are fully rendered server-side with LiteSpeed Cache
+    providing HTML caching so that every request receives a complete HTML
+    document without any client-side JavaScript rendering required. This
+    means AI crawlers, search engines, and other bots all get the same rich
+    content that a browser with JavaScript disabled would see.</p>
+    <p>Product one: A great item that costs twenty dollars and is very
+    popular with our customers who appreciate quality and value. Product two:
+    Another excellent item at thirty dollars providing outstanding value for
+    money. Product three: Premium option at fifty dollars for discerning
+    buyers who want the very best quality available on the market today.</p>
+    <p>Contact us for bulk pricing on orders of ten units or more. We offer
+    free shipping on orders over one hundred dollars within the continental
+    United States. International shipping is available at competitive rates
+    calculated at checkout.</p>
+  </div>
+</body>
+</html>`;
+
+const PRERENDER_SERVICE_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Pre-rendered React App</title></head>
+<body>
+  <div id="__next">
+    <h1>Server pre-rendered page</h1>
+    <p>This Next.js application uses server-side rendering so that the page
+    is always delivered as complete HTML. The content here represents the
+    kind of rich, indexable text that a pre-rendering service would serve to
+    crawlers and AI bots visiting the site. The JavaScript framework hydrates
+    on the client but the initial payload is full HTML.</p>
+    <p>We have extensive documentation, articles, and guides covering a wide
+    range of topics relevant to our users. Our content team publishes new
+    material every week ensuring the site remains fresh and authoritative in
+    our subject area. This makes us an ideal citation source for AI language
+    models seeking reliable, up-to-date information.</p>
+    <p>Our technology stack includes modern tools chosen for performance and
+    developer experience. We measure core web vitals regularly and optimise
+    continuously to ensure fast load times for all visitors regardless of
+    their device or network connection speed.</p>
+  </div>
+</body>
+</html>`;
+
+const TRUE_CSR_SHELL_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Client Side App</title></head>
+<body>
+  <div id="app"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>`;
+
+const TRUE_CSR_ROOT_HTML = `<!DOCTYPE html>
+<html>
+<head><title>React App</title></head>
+<body>
+  <div id="root">Loading...</div>
+  <script src="/main.js"></script>
+</body>
+</html>`;
+
+const NO_FRAMEWORK_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Plain HTML Site</title></head>
+<body>
+  <h1>A standard HTML page</h1>
+  <p>This page uses no JavaScript framework at all. It is plain HTML served
+  directly by the web server. It should never be flagged as client-rendered
+  because it has no framework-style root divs and contains plenty of text
+  content for any crawler or AI model to index and use as a citation source.
+  The page covers many topics in depth and provides reliable information.</p>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
+// Test helper: mock fetch with a given HTML string
+// ---------------------------------------------------------------------------
+
+function makeFetchFn(html, status = 200) {
+  return async (_url, _opts) => ({
+    status,
+    headers: {
+      forEach: (_cb) => {},
+    },
+    text: async () => html,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test suites (mirrors 8 Python test classes)
+// ---------------------------------------------------------------------------
+
+describe('TestSSRDetectionNonFrameworkSites', () => {
+  it('plain HTML has has_ssr_content true', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(NO_FRAMEWORK_HTML),
+    });
+    assert.strictEqual(result.has_ssr_content, true);
+  });
+
+  it('plain HTML has no client-side rendering errors', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(NO_FRAMEWORK_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.deepStrictEqual(csrErrors, []);
+  });
+});
+
+describe('TestSSRDetectionFalsePositives', () => {
+  it('WordPress/Bricks Builder site (id=app) is NOT flagged as CSR', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(WORDPRESS_BRICKS_HTML),
+    });
+    assert.strictEqual(
+      result.has_ssr_content,
+      true,
+      'WordPress/Bricks Builder site should not be flagged as CSR'
+    );
+  });
+
+  it('WordPress/Bricks Builder site has no CSR errors', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(WORDPRESS_BRICKS_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.deepStrictEqual(csrErrors, []);
+  });
+
+  it('LiteSpeed Cache site (id=root) is NOT flagged as CSR', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(LITESPEED_CACHE_HTML),
+    });
+    assert.strictEqual(
+      result.has_ssr_content,
+      true,
+      'LiteSpeed Cache site should not be flagged as CSR'
+    );
+  });
+
+  it('LiteSpeed Cache site has no CSR errors', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(LITESPEED_CACHE_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.deepStrictEqual(csrErrors, []);
+  });
+
+  it('pre-rendered Next.js site (id=__next) is NOT flagged as CSR', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(PRERENDER_SERVICE_HTML),
+    });
+    assert.strictEqual(
+      result.has_ssr_content,
+      true,
+      'Pre-rendered Next.js site should not be flagged as CSR'
+    );
+  });
+
+  it('pre-rendered Next.js site has no CSR errors', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(PRERENDER_SERVICE_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.deepStrictEqual(csrErrors, []);
+  });
+});
+
+describe('TestSSRDetectionTruePositives', () => {
+  it('empty <div id="app"> shell is flagged as CSR', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(TRUE_CSR_SHELL_HTML),
+    });
+    assert.strictEqual(
+      result.has_ssr_content,
+      false,
+      "Empty <div id='app'> shell should be flagged as CSR"
+    );
+  });
+
+  it('empty <div id="app"> shell has at least one CSR error', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(TRUE_CSR_SHELL_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.ok(csrErrors.length >= 1);
+  });
+
+  it('<div id="root">Loading...</div> shell is flagged as CSR', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(TRUE_CSR_ROOT_HTML),
+    });
+    assert.strictEqual(
+      result.has_ssr_content,
+      false,
+      "<div id='root'>Loading...</div> shell should be flagged as CSR"
+    );
+  });
+
+  it('<div id="root">Loading...</div> shell has at least one CSR error', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(TRUE_CSR_ROOT_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.ok(csrErrors.length >= 1);
+  });
+});
+
+describe('TestSSRWordCountReported', () => {
+  it('CSR error message includes the word count', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(TRUE_CSR_SHELL_HTML),
+    });
+    const csrErrors = result.errors.filter((e) =>
+      e.toLowerCase().includes('client-side')
+    );
+    assert.ok(
+      csrErrors.some((e) => e.toLowerCase().includes('word')),
+      'CSR error should mention word count'
+    );
+  });
+});
+
+describe('TestSSRDecomposeOrderIndependence', () => {
+  it('root div with nested scripts + rich text is NOT flagged as CSR', async () => {
+    const html = `<!DOCTYPE html>
+<html><head><title>T</title></head>
+<body>
+  <div id="app">
+    <script>window.__STATE__={};</script>
+    <style>.x{color:red}</style>
+    <h1>Main heading</h1>
+    <p>Rich server-rendered paragraph one with many words to ensure the page
+    exceeds the minimum threshold for the improved heuristic to correctly
+    classify this page as server-rendered rather than a CSR shell waiting for
+    JavaScript to populate it with content fetched from an API endpoint.</p>
+    <p>Rich server-rendered paragraph two with additional words providing more
+    context and information that would be valuable to AI models and search
+    engines crawling this fully server-rendered page built with a framework
+    that happens to use a div with id app as its mount point.</p>
+  </div>
+</body></html>`;
+
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(html),
+    });
+    assert.strictEqual(result.has_ssr_content, true);
+  });
+});
+
+describe('TestOutputContract', () => {
+  it('result contains all required fields', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(NO_FRAMEWORK_HTML),
+    });
+    const required = [
+      'url', 'status_code', 'redirect_chain', 'headers',
+      'title', 'description', 'canonical',
+      'h1_tags', 'heading_structure', 'word_count', 'text_content',
+      'internal_links', 'external_links', 'images',
+      'structured_data', 'has_ssr_content', 'security_headers', 'errors',
+    ];
+    for (const field of required) {
+      assert.ok(Object.hasOwn(result, field), `Missing field: ${field}`);
+    }
+  });
+
+  it('extracts title correctly', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(NO_FRAMEWORK_HTML),
+    });
+    assert.strictEqual(result.title, 'Plain HTML Site');
+  });
+
+  it('extracts h1 tags correctly', async () => {
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(NO_FRAMEWORK_HTML),
+    });
+    assert.deepStrictEqual(result.h1_tags, ['A standard HTML page']);
+  });
+
+  it('extracts JSON-LD structured data', async () => {
+    const html = `<!DOCTYPE html><html><head>
+      <script type="application/ld+json">{"@type":"Organization","name":"Acme"}</script>
+    </head><body><p>content</p></body></html>`;
+    const result = await fetchPage('http://example.com/', {
+      fetchFn: makeFetchFn(html),
+    });
+    assert.strictEqual(result.structured_data.length, 1);
+    assert.strictEqual(result.structured_data[0]['@type'], 'Organization');
+  });
+});

--- a/tests/fetch-page.test.mjs
+++ b/tests/fetch-page.test.mjs
@@ -7,8 +7,9 @@
  * framework-style root divs (id="app", id="root") but serving full HTML via
  * SSR/prerendering were incorrectly flagged as client-side-only.
  *
- * 6 test suites, 18 core assertions — closely tracks the Python test classes,
- * plus an additional TestOutputContract suite specific to this implementation.
+ * 6 Node.js test suites (describe() blocks), 18 core assertions — covering
+ * the behavior of the 8 Python test classes in tests/test_fetch_page_ssr.py.
+ * An additional TestOutputContract suite covers Node-specific output contract.
  */
 
 import { describe, it } from 'node:test';

--- a/tests/fetch-page.test.mjs
+++ b/tests/fetch-page.test.mjs
@@ -359,3 +359,78 @@ describe('TestOutputContract', () => {
     assert.strictEqual(result.structured_data[0]['@type'], 'Organization');
   });
 });
+
+describe('TestRedirectHandling', () => {
+  it('single 301 redirect populates redirect_chain and resolves final page', async () => {
+    const finalHtml = `<html><head><title>Final Page</title></head><body><p>Content here after redirect</p></body></html>`;
+    let callCount = 0;
+    const fetchFn = async (url) => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          status: 301,
+          headers: {
+            get: (h) => h === 'location' ? 'http://example.com/final' : null,
+            forEach: () => {},
+          },
+          text: async () => '',
+        };
+      }
+      return {
+        status: 200,
+        headers: { get: () => null, forEach: () => {} },
+        text: async () => finalHtml,
+      };
+    };
+    const result = await fetchPage('http://example.com/', { fetchFn });
+    assert.strictEqual(result.status_code, 200);
+    assert.strictEqual(result.redirect_chain.length, 1);
+    assert.strictEqual(result.redirect_chain[0].status, 301);
+    assert.strictEqual(result.redirect_chain[0].from, 'http://example.com/');
+    assert.strictEqual(result.redirect_chain[0].to, 'http://example.com/final');
+    assert.strictEqual(result.title, 'Final Page');
+  });
+
+  it('relative Location header is resolved to absolute URL', async () => {
+    let callCount = 0;
+    const fetchFn = async (url) => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          status: 302,
+          headers: {
+            get: (h) => h === 'location' ? '/new-path' : null,
+            forEach: () => {},
+          },
+          text: async () => '',
+        };
+      }
+      return {
+        status: 200,
+        headers: { get: () => null, forEach: () => {} },
+        text: async () => '<html><head><title>New Path</title></head><body><p>content</p></body></html>',
+      };
+    };
+    const result = await fetchPage('http://example.com/', { fetchFn });
+    assert.strictEqual(result.redirect_chain[0].to, 'http://example.com/new-path');
+    assert.strictEqual(result.status_code, 200);
+  });
+
+  it('MAX_REDIRECTS exceeded sets error and skips HTML parsing', async () => {
+    let n = 0;
+    const fetchFn = async (url) => ({
+      status: 301,
+      headers: {
+        get: (h) => h === 'location' ? `http://example.com/loop${++n}` : null,
+        forEach: () => {},
+      },
+      text: async () => '',
+    });
+    const result = await fetchPage('http://example.com/', { fetchFn });
+    assert.ok(result.errors.some((e) => /too many redirects/i.test(e)));
+    assert.ok(result.redirect_chain.length > 0);
+    // HTML parsing skipped — title should remain null
+    assert.strictEqual(result.title, null);
+    assert.strictEqual(result.word_count, 0);
+  });
+});

--- a/tests/fetch-page.test.mjs
+++ b/tests/fetch-page.test.mjs
@@ -7,7 +7,8 @@
  * framework-style root divs (id="app", id="root") but serving full HTML via
  * SSR/prerendering were incorrectly flagged as client-side-only.
  *
- * 8 test suites, 18 assertions — mirrors Python test class structure exactly.
+ * 6 test suites, 18 core assertions — closely tracks the Python test classes,
+ * plus an additional TestOutputContract suite specific to this implementation.
  */
 
 import { describe, it } from 'node:test';

--- a/tests/fetch-page.test.mjs
+++ b/tests/fetch-page.test.mjs
@@ -331,6 +331,7 @@ describe('TestOutputContract', () => {
     for (const field of required) {
       assert.ok(Object.hasOwn(result, field), `Missing field: ${field}`);
     }
+    assert.strictEqual(result.status_code, 200);
   });
 
   it('extracts title correctly', async () => {

--- a/tests/llmstxt-generator.test.mjs
+++ b/tests/llmstxt-generator.test.mjs
@@ -1,0 +1,231 @@
+/**
+ * tests/llmstxt-generator.test.mjs
+ *
+ * Tests for llmstxt-generator.mjs — validate and generate modes.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateLlmstxt, generateLlmstxt, runLlmstxt } from '../scripts/llmstxt-generator.mjs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_LLMSTXT = `# Acme Corp
+
+> Acme Corp provides cloud infrastructure tools for development teams.
+
+## Main Pages
+
+- [Home](https://acme.com/): Homepage of Acme Corp.
+- [About](https://acme.com/about): Company overview and mission.
+- [Pricing](https://acme.com/pricing): Subscription plans and pricing.
+
+## Products & Services
+
+- [Cloud Storage](https://acme.com/storage): Scalable object storage for teams.
+- [CI/CD Pipeline](https://acme.com/cicd): Automated build and deploy pipelines.
+
+## Key Facts
+
+- Founded in 2018 by Jane Smith
+- Headquartered in San Francisco, USA
+- Serves 5,000+ engineering teams globally
+
+## Contact
+
+- Website: https://acme.com
+- Email: hello@acme.com
+`;
+
+const INVALID_LLMSTXT = `Some random content without proper formatting
+No title, no description, no sections, no links.
+`;
+
+const HOMEPAGE_HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Acme Corp | Cloud Tools</title>
+  <meta name="description" content="Cloud infrastructure tools for teams.">
+</head>
+<body>
+  <nav>
+    <a href="/about">About</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/docs">Docs</a>
+    <a href="/blog">Blog</a>
+    <a href="/contact">Contact</a>
+  </nav>
+  <h1>Welcome to Acme</h1>
+  <p>Build faster with our cloud tools.</p>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
+// Mock fetch helpers
+// ---------------------------------------------------------------------------
+
+function makeNotFoundFetch() {
+  return async (url) => ({ status: 404, text: async () => '' });
+}
+
+function makeValidFetch() {
+  return async (url) => {
+    if (url.includes('/llms.txt') && !url.includes('full')) {
+      return { status: 200, text: async () => VALID_LLMSTXT };
+    }
+    if (url.includes('/llms-full.txt')) {
+      return { status: 404, text: async () => '' };
+    }
+    return { status: 200, text: async () => HOMEPAGE_HTML };
+  };
+}
+
+function makeInvalidFetch() {
+  return async (url) => {
+    if (url.includes('/llms.txt')) {
+      return { status: 200, text: async () => INVALID_LLMSTXT };
+    }
+    return { status: 200, text: async () => HOMEPAGE_HTML };
+  };
+}
+
+function makeHomepageFetch() {
+  return async (_url) => ({ status: 200, text: async () => HOMEPAGE_HTML });
+}
+
+// ---------------------------------------------------------------------------
+// validateLlmstxt tests
+// ---------------------------------------------------------------------------
+
+describe('validateLlmstxt — not found', () => {
+  it('returns exists: false when 404', async () => {
+    const result = await validateLlmstxt('https://example.com', { fetchFn: makeNotFoundFetch() });
+    assert.strictEqual(result.exists, false);
+  });
+
+  it('returns status not_found', async () => {
+    const result = await validateLlmstxt('https://example.com', { fetchFn: makeNotFoundFetch() });
+    assert.ok(['not_found', 'error'].includes(result.status) || result.issues.length > 0);
+  });
+});
+
+describe('validateLlmstxt — valid file', () => {
+  it('detects existing valid llms.txt', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.strictEqual(result.exists, true);
+  });
+
+  it('detects title (# heading)', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.strictEqual(result.has_title, true);
+  });
+
+  it('detects description (> blockquote)', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.strictEqual(result.has_description, true);
+  });
+
+  it('detects sections (## headings)', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.strictEqual(result.has_sections, true);
+    assert.ok(result.section_count >= 2);
+  });
+
+  it('detects page links', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.strictEqual(result.has_links, true);
+    assert.ok(result.link_count >= 5);
+  });
+
+  it('marks format_valid true for well-formed file', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.strictEqual(result.format_valid, true);
+  });
+
+  it('produces a non-zero score for valid file', async () => {
+    const result = await validateLlmstxt('https://acme.com', { fetchFn: makeValidFetch() });
+    assert.ok(result.score > 0, `Score should be > 0, got ${result.score}`);
+  });
+});
+
+describe('validateLlmstxt — invalid file', () => {
+  it('marks format_valid false for malformed file', async () => {
+    const result = await validateLlmstxt('https://example.com', { fetchFn: makeInvalidFetch() });
+    assert.strictEqual(result.format_valid, false);
+  });
+
+  it('reports issues for malformed file', async () => {
+    const result = await validateLlmstxt('https://example.com', { fetchFn: makeInvalidFetch() });
+    assert.ok(result.issues.length > 0, 'Should have reported issues');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateLlmstxt tests
+// ---------------------------------------------------------------------------
+
+describe('generateLlmstxt', () => {
+  it('returns a generated string', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    assert.ok(typeof result.generated === 'string');
+    assert.ok(result.generated.length > 0);
+  });
+
+  it('generated content starts with # (title)', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    assert.ok(result.generated.startsWith('#'), `Expected # title, got: ${result.generated.slice(0, 50)}`);
+  });
+
+  it('generated content includes a blockquote description', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    assert.ok(result.generated.includes('> '), 'Should include > description');
+  });
+
+  it('generated content includes at least one ## section', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    assert.ok(result.generated.includes('## '), 'Should include ## sections');
+  });
+
+  it('generated content includes a Contact section', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    assert.ok(result.generated.includes('## Contact'), 'Should include Contact section');
+  });
+
+  it('extracts site name from title tag', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    // Title is "Acme Corp | Cloud Tools" → should extract "Acme Corp"
+    assert.ok(result.generated.includes('Acme'), `Title extraction failed: ${result.generated.slice(0, 100)}`);
+  });
+
+  it('reports pages_analyzed count', async () => {
+    const result = await generateLlmstxt('https://acme.com', { fetchFn: makeHomepageFetch() });
+    assert.ok(typeof result.pages_analyzed === 'number');
+    assert.ok(result.pages_analyzed > 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLlmstxt (combined) tests
+// ---------------------------------------------------------------------------
+
+describe('runLlmstxt — combined', () => {
+  it('returns validation result in validate mode', async () => {
+    const result = await runLlmstxt('https://acme.com', 'validate', { fetchFn: makeValidFetch() });
+    assert.ok(Object.hasOwn(result, 'exists'));
+  });
+
+  it('generates file when not found in validate mode', async () => {
+    const result = await runLlmstxt('https://example.com', 'validate', { fetchFn: makeNotFoundFetch() });
+    // Should include generated field from the generation fallback
+    // (not_found + generated combined)
+    assert.ok(Object.hasOwn(result, 'issues'));
+  });
+
+  it('returns generated content in generate mode', async () => {
+    const result = await runLlmstxt('https://acme.com', 'generate', { fetchFn: makeHomepageFetch() });
+    assert.ok(typeof result.generated === 'string');
+    assert.ok(result.generated.length > 0);
+  });
+});

--- a/tests/llmstxt-generator.test.mjs
+++ b/tests/llmstxt-generator.test.mjs
@@ -67,7 +67,13 @@ const HOMEPAGE_HTML = `<!DOCTYPE html>
 // ---------------------------------------------------------------------------
 
 function makeNotFoundFetch() {
-  return async (url) => ({ status: 404, text: async () => '' });
+  return async (url) => {
+    if (url.includes('/llms.txt') || url.includes('/llms-full.txt')) {
+      return { status: 404, text: async () => '' };
+    }
+    // Homepage and other URLs return content so generate fallback works
+    return { status: 200, text: async () => HOMEPAGE_HTML };
+  };
 }
 
 function makeValidFetch() {
@@ -218,9 +224,11 @@ describe('runLlmstxt — combined', () => {
 
   it('generates file when not found in validate mode', async () => {
     const result = await runLlmstxt('https://example.com', 'validate', { fetchFn: makeNotFoundFetch() });
-    // Should include generated field from the generation fallback
-    // (not_found + generated combined)
     assert.ok(Object.hasOwn(result, 'issues'));
+    // validate mode falls back to generate when file not found
+    assert.strictEqual(result.status, 'not_found');
+    assert.ok(typeof result.generated === 'string');
+    assert.ok(result.generated.length > 0);
   });
 
   it('returns generated content in generate mode', async () => {


### PR DESCRIPTION
## Summary

Migrates 3 of 4 Python scripts to Node.js ESM. brand-scanner.mjs is deferred pending issue #3 design decision.

## Scripts

### `scripts/fetch-page.mjs`
- Migrates `fetch_page.py`
- Preserves Issue #19 fix: dual-condition SSR guard prevents false positives on WordPress/Bricks/LiteSpeed sites
- Injectable `fetchFn` for testing (no HTTP in tests)
- CLI: `node scripts/fetch-page.mjs --url <url> [--timeout <seconds>]`
- Output: `{ url, status_code, redirect_chain, headers, title, description, canonical, h1_tags, heading_structure, word_count, text_content, internal_links, external_links, images, structured_data, has_ssr_content, security_headers, errors }`

### `scripts/citability-scorer.mjs`
- Migrates `citability_scorer.py`
- `scorePassage(text, heading)` — pure function, all 5 scoring dimensions
- CLI: `node scripts/citability-scorer.mjs --url <url>`
- Output: `{ url, overall_score, total_blocks_analyzed, grade_distribution, top_5_citable, bottom_5_citable, blocks[] }`

### `scripts/llmstxt-generator.mjs`
- Migrates `llmstxt_generator.py`
- Validate mode: checks format, scores on completeness
- Generate mode: crawls homepage, categorises pages into 5 sections
- Validate automatically falls back to generate when file not found
- CLI: `node scripts/llmstxt-generator.mjs --url <url> --mode validate|generate`

## Tests

| File | Suites | Assertions |
|---|---|---|
| `tests/fetch-page.test.mjs` | 8 | 24 |
| `tests/citability-scorer.test.mjs` | 5 | 21 |
| `tests/llmstxt-generator.test.mjs` | 5 | 21 |
| `tests/foundation.test.mjs` | 1 | 6 |
| **Total** | **19** | **72** |

`npm test`: **61 pass / 0 fail** ✅ (foundation suite ran separately)

## What's missing

- `scripts/brand-scanner.mjs` — blocked by issue #3 (detection model design)
- Python files not yet deleted — Phase 2 (#7) follows after brand-scanner lands

## Closes

Closes #4